### PR TITLE
Fix bug with log message getting included in generated SQL when piping to file

### DIFF
--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -55,7 +55,7 @@ impl Migrator {
             None
         };
         let script_path = &self.config.pather().migration_script_file_path(&self.name);
-        println!("generate script path: {}", script_path);
+        eprintln!("generate script path: {}", script_path);
         template::generate_streaming(&self.config, lock_file, script_path, variables).await
     }
 }


### PR DESCRIPTION
Use `eprintln` so output goes to stderr and not a file when piping output

# Description

<!-- Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. -->

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] I confirm that **I have read and signed the [Contributor License Agreement](CLA.md)** linked below.
- [x] My contribution is original and I have the right to submit it.
- [x] I have listed any third-party code or licences in this PR description.
- [x] Unit tests are included.
- [x] I have looked over this PR first before asking for reviews.

## Issue

- Issue Link: [Issue Number or Link]

## Comments

<!-- Any other information or context you would like to provide? -->
