### PR TITLE
fix to use pinned read_file when pinned

### DIFF
--- a/docs/src/content/docs/guides/manage-databases.md
+++ b/docs/src/content/docs/guides/manage-databases.md
@@ -158,6 +158,21 @@ command = {
 
 4. **Reuse**: This final command is cached and reused for all SQL operations in that spawn session.
 
+### Avoiding Repeated SSH Passphrase Prompts
+
+When using SSH keys with a passphrase, each connection to the database will prompt for the passphrase. Since spawn opens multiple SSH sessions during a single `apply` run, this gets tedious quickly.
+
+To avoid this, add your key to the SSH agent before running spawn:
+
+```bash
+# macOS
+ssh-add ~/.ssh/your_key
+
+# Linux
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/your_key
+```
+
 ### Complete Example: Multiple Environments
 
 ```toml

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -125,10 +125,14 @@ impl Store {
         Ok(res)
     }
 
+    pub async fn load_component_bytes(&self, name: &str) -> Result<Option<Vec<u8>>> {
+        self.pinner.load_bytes(name, &self.fs).await
+    }
+
     pub async fn read_file_bytes(&self, path: &str) -> Result<Vec<u8>> {
-        let full_path = format!("{}/{}", self.pather.components_folder(), path);
-        let result = self.fs.read(&full_path).await?;
-        Ok(result.to_bytes().to_vec())
+        self.load_component_bytes(path)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("file not found in components: {}", path))
     }
 
     pub async fn load_migration(&self, name: &str) -> Result<String> {

--- a/src/store/pinner/latest.rs
+++ b/src/store/pinner/latest.rs
@@ -25,15 +25,13 @@ impl Latest {
 #[async_trait]
 impl Pinner for Latest {
     /// Returns the file from the live file system if it exists.
-    async fn load(&self, name: &str, object_store: &Operator) -> Result<Option<String>> {
+    async fn load_bytes(&self, name: &str, object_store: &Operator) -> Result<Option<Vec<u8>>> {
         let path_str = format!("{}/components/{}", self.store_path, name);
 
         let get_result = object_store.read(&path_str).await?;
         let bytes = get_result.to_bytes();
-        let result = Ok::<Vec<u8>, object_store::Error>(bytes.to_vec());
-        let res = result.map(|bytes| String::from_utf8(bytes).ok())?;
 
-        Ok(res)
+        Ok(Some(bytes.to_vec()))
     }
 
     async fn snapshot(&mut self, _object_store: &Operator) -> Result<String> {

--- a/src/store/pinner/mod.rs
+++ b/src/store/pinner/mod.rs
@@ -13,7 +13,15 @@ pub mod spawn;
 
 #[async_trait]
 pub trait Pinner: Debug + Send + Sync {
-    async fn load(&self, name: &str, fs: &Operator) -> Result<Option<String>>;
+    async fn load_bytes(&self, name: &str, fs: &Operator) -> Result<Option<Vec<u8>>>;
+
+    async fn load(&self, name: &str, fs: &Operator) -> Result<Option<String>> {
+        match self.load_bytes(name, fs).await? {
+            Some(bytes) => Ok(Some(String::from_utf8(bytes)?)),
+            None => Ok(None),
+        }
+    }
+
     async fn snapshot(&mut self, fs: &Operator) -> Result<String>;
 }
 

--- a/src/store/pinner/spawn.rs
+++ b/src/store/pinner/spawn.rs
@@ -89,7 +89,7 @@ impl Spawn {
 #[async_trait]
 impl Pinner for Spawn {
     /// Returns the file from the store if it exists.
-    async fn load(&self, name: &str, object_store: &Operator) -> Result<Option<String>> {
+    async fn load_bytes(&self, name: &str, object_store: &Operator) -> Result<Option<Vec<u8>>> {
         // Borrow files from inside self.files, if not none:
         let files = self
             .files
@@ -100,8 +100,7 @@ impl Pinner for Spawn {
             match object_store.read(path).await {
                 Ok(get_result) => {
                     let bytes = get_result.to_bytes();
-                    let contents = String::from_utf8(bytes.to_vec())?;
-                    Ok(Some(contents))
+                    Ok(Some(bytes.to_vec()))
                 }
                 Err(_) => Ok(None),
             }


### PR DESCRIPTION
read file in templates doesn't use pinned version of file when running pinned.  This fixes.