### PR TITLE
allow reusing connection for some of our actions when applying in bulk

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,6 +133,11 @@ pub enum MigrationCommands {
         /// Retry a previously failed migration
         #[arg(long)]
         retry: bool,
+
+        /// Reuse the same database connection across all migrations.
+        /// Can significantly speed up applying many migrations.
+        #[arg(long)]
+        reuse_connection: bool,
     },
     /// Mark a migration as applied without actually running it.
     /// Useful when a migration was applied manually and needs to be recorded.
@@ -168,12 +173,14 @@ impl TelemetryDescribe for MigrationCommands {
                 variables,
                 migration,
                 retry,
+                reuse_connection,
                 ..
             } => TelemetryInfo::new("apply").with_properties(vec![
                 ("opt_no_pin", no_pin.to_string()),
                 ("opt_retry", retry.to_string()),
                 ("has_variables", variables.is_some().to_string()),
                 ("apply_all", migration.is_none().to_string()),
+                ("opt_reuse_connection", reuse_connection.to_string()),
             ]),
             MigrationCommands::Adopt { .. } => TelemetryInfo::new("adopt"),
             MigrationCommands::Status => TelemetryInfo::new("status"),
@@ -332,6 +339,7 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
                     variables,
                     yes,
                     retry,
+                    reuse_connection,
                 }) => {
                     let vars = match variables {
                         Some(vars_path) => Some(config.load_variables_from_path(&vars_path).await?),
@@ -343,6 +351,7 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
                         variables: vars,
                         yes,
                         retry,
+                        reuse_connection,
                     }
                     .execute(config)
                     .await

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -1,7 +1,7 @@
 use crate::commands::migration::get_pending_and_confirm;
 use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
 use crate::config::Config;
-use crate::engine::MigrationError;
+use crate::engine::{Engine, MigrationError};
 use crate::migrator::Migrator;
 use crate::variables::Variables;
 use anyhow::{anyhow, Result};
@@ -12,6 +12,7 @@ pub struct ApplyMigration {
     pub variables: Option<Variables>,
     pub yes: bool,
     pub retry: bool,
+    pub reuse_connection: bool,
 }
 
 impl TelemetryDescribe for ApplyMigration {
@@ -20,6 +21,7 @@ impl TelemetryDescribe for ApplyMigration {
             ("opt_pinned", self.pinned.to_string()),
             ("has_variables", self.variables.is_some().to_string()),
             ("apply_all", self.migration.is_none().to_string()),
+            ("opt_reuse_connection", self.reuse_connection.to_string()),
         ])
     }
 }
@@ -35,6 +37,14 @@ impl Command for ApplyMigration {
         };
 
         let total = migrations.len();
+
+        // Optionally reuse the same engine (database connection) across all migrations
+        let shared_engine = if self.reuse_connection {
+            Some(config.new_engine().await?)
+        } else {
+            None
+        };
+
         for (i, migration) in migrations.into_iter().enumerate() {
             let counter = if total > 1 {
                 format!(
@@ -49,7 +59,15 @@ impl Command for ApplyMigration {
             let mgrtr = Migrator::new(config, &migration, self.pinned);
             match mgrtr.generate_streaming(self.variables.clone()).await {
                 Ok(streaming) => {
-                    let engine = config.new_engine().await?;
+                    // Use shared engine if reuse_connection is enabled, otherwise create new
+                    let new_engine: Option<Box<dyn Engine>>;
+                    let engine: &dyn Engine = match &shared_engine {
+                        Some(e) => e.as_ref(),
+                        None => {
+                            new_engine = Some(config.new_engine().await?);
+                            new_engine.as_ref().unwrap().as_ref()
+                        }
+                    };
                     let write_fn = streaming.into_writer_fn();
                     match engine
                         .migration_apply(

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -304,6 +304,7 @@ impl IntegrationTestHelper {
             variables: None,
             yes: true,
             retry: false,
+            reuse_connection: false,
         };
 
         let outcome = cmd.execute(&config).await?;
@@ -417,7 +418,8 @@ fn require_postgres() -> Result<()> {
 async fn test_mass_apply_and_adopt() -> Result<()> {
     require_postgres()?;
 
-    for mode in ["apply", "adopt"] {
+    // Test both apply modes (with and without connection reuse) and adopt
+    for (mode, reuse_connection) in [("apply", false), ("apply_reuse", true), ("adopt", false)] {
         let test_name = format!("test_mass_{}", mode);
         let helper = IntegrationTestHelper::new(&test_name, None).await?;
 
@@ -461,18 +463,20 @@ COMMIT;"#
         // Mass apply/adopt the remaining pending migrations
         let config = helper.migration_helper.load_config().await?;
         let expected_activity = match mode {
-            "apply" => {
+            "apply" | "apply_reuse" => {
                 let cmd = ApplyMigration {
                     migration: None,
                     pinned: false,
                     variables: None,
                     yes: true,
                     retry: false,
+                    reuse_connection,
                 };
                 let outcome = cmd.execute(&config).await?;
                 assert!(
                     matches!(outcome, Outcome::AppliedMigrations),
-                    "mass apply should return AppliedMigrations"
+                    "mass apply (reuse_connection={}) should return AppliedMigrations",
+                    reuse_connection
                 );
                 "APPLY"
             }
@@ -1286,6 +1290,7 @@ COMMIT;"#;
         variables: None,
         yes: true,
         retry: false,
+        reuse_connection: false,
     };
     let result = cmd.execute(&config).await;
     assert!(
@@ -1306,6 +1311,7 @@ COMMIT;"#;
         variables: None,
         yes: true,
         retry: true,
+        reuse_connection: false,
     };
     let result = cmd.execute(&config).await;
     assert!(
@@ -1551,6 +1557,7 @@ COMMIT;"#;
         variables: None,
         yes: true,
         retry: false,
+        reuse_connection: false,
     };
     let result = cmd.execute(&config).await;
     assert!(
@@ -1571,6 +1578,7 @@ COMMIT;"#;
         variables: None,
         yes: true,
         retry: false,
+        reuse_connection: false,
     };
     let result = cmd.execute(&config).await;
     assert!(result.is_ok(), "apply with --no-pin should succeed");
@@ -1667,6 +1675,7 @@ COMMIT;"#
         variables: None,
         yes: true,
         retry: false,
+        reuse_connection: false,
     };
     cmd.execute(&config).await?;
 
@@ -1719,6 +1728,7 @@ COMMIT;"#
         variables: None,
         yes: true,
         retry: false,
+        reuse_connection: false,
     };
     cmd2.execute(&config2).await.expect(
         "Re-applying the same migration should succeed (detected as already applied), \


### PR DESCRIPTION
Just a small change for now, with more to come.  If we reuse psql connections, then migrations can be applied in bulk faster.