### PR TITLE
Tab completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ CURRENT.md
 /play
 
 .DS_Store
+build_test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -258,10 +258,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.5.13"
+name = "clap_complete"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -271,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -1010,6 +1022,15 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1892,6 +1913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +1967,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "clap_complete",
  "config",
  "console",
  "dialoguer",
@@ -1956,7 +1984,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "shlex",
+ "shlex 1.3.0",
  "similar",
  "tabled",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.13", features = ["color", "derive"] }
+clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
 minijinja = { version = "2.11.0", features = ["loader"] }
 toml = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/src/content/docs/cli/completions.mdx
+++ b/docs/src/content/docs/cli/completions.mdx
@@ -16,9 +16,14 @@ Spawn supports dynamic shell completions for Bash, Zsh, Fish, PowerShell, and El
 
 Add to your `~/.zshrc`:
 
-```bash
+```zsh
+# Initialize zsh completion system (skip if using oh-my-zsh, prezto, etc.)
+autoload -Uz compinit && compinit
+
 source <(COMPLETE=zsh spawn)
 ```
+
+If you're using a zsh framework like oh-my-zsh or prezto, it already initializes `compinit`, so you only need the `source` line.
 
 ### Bash
 

--- a/docs/src/content/docs/cli/completions.mdx
+++ b/docs/src/content/docs/cli/completions.mdx
@@ -1,0 +1,79 @@
+---
+title: Shell Completions
+description: Enable tab completion for spawn commands.
+---
+
+Spawn supports dynamic shell completions for Bash, Zsh, Fish, PowerShell, and Elvish. Completions are context-aware and include migration names, test names, and all command options.
+
+## Features
+
+- **Dynamic completions**: Always reflects current migrations and tests in your project
+- **Fuzzy-friendly**: Works with shell fuzzy finders like fzf-tab
+
+## Setup
+
+### Zsh
+
+Add to your `~/.zshrc`:
+
+```bash
+source <(COMPLETE=zsh spawn)
+```
+
+### Bash
+
+Add to your `~/.bashrc`:
+
+```bash
+source <(COMPLETE=bash spawn)
+```
+
+### Fish
+
+Add to your Fish config (`~/.config/fish/config.fish`):
+
+```fish
+COMPLETE=fish spawn | source
+```
+
+### PowerShell
+
+Add to your PowerShell profile:
+
+```powershell
+Invoke-Expression (& { $env:COMPLETE="powershell"; spawn })
+```
+
+### Elvish
+
+Add to your Elvish config:
+
+```elvish
+eval (COMPLETE=elvish spawn | slurp)
+```
+
+## Usage
+
+After setup, use Tab to complete:
+
+```bash
+# Complete subcommands
+spawn migr<TAB>
+# → spawn migration
+
+# Complete migration names
+spawn migration build <TAB>
+# → 20260102030405-add-users
+# → 20260103120000-create-posts
+
+# Complete test names
+spawn test run <TAB>
+# → my-test
+# → another-test
+```
+
+## Fuzzy Finder Integration
+
+When working with many timestamped migrations, a fuzzy finder like [fzf-tab](https://github.com/Aloxaf/fzf-tab) can help you quickly filter by typing any part of the migration name.
+
+With fzf-tab installed, pressing Tab opens an interactive fzf menu where you can type `add-users` to filter to `20260102030405-add-users`, even though the completion value starts with a timestamp.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,11 +3,13 @@ use crate::commands::{
     ExpectTest, Init, MigrationStatus, NewMigration, NewTest, Outcome, PinMigration, RunTest,
     TelemetryDescribe, TelemetryInfo,
 };
-use crate::config::Config;
+use crate::completions::{complete_migrations, complete_tests};
+use crate::config::{Config, DEFAULT_CONFIG_FILE};
 use opendal::Operator;
 
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
+use clap_complete::ArgValueCompleter;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -16,7 +18,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub debug: bool,
 
-    #[arg(global = true, short, long, default_value = "spawn.toml")]
+    #[arg(global = true, short, long, default_value = DEFAULT_CONFIG_FILE)]
     pub config_file: String,
 
     #[arg(global = true, long)]
@@ -97,6 +99,7 @@ pub enum MigrationCommands {
     /// Pin a migration with current components
     Pin {
         /// Migration to pin
+        #[arg(add = ArgValueCompleter::new(complete_migrations))]
         migration: String,
     },
     /// Build a migration into SQL
@@ -106,6 +109,7 @@ pub enum MigrationCommands {
         pinned: bool,
         /// Migration to build.  Looks for up.sql inside this specified
         /// migration folder.
+        #[arg(add = ArgValueCompleter::new(complete_migrations))]
         migration: String,
         /// Path to a variables file (JSON, TOML, or YAML) to use for templating.
         /// Overrides the variables_file setting in spawn.toml.
@@ -119,6 +123,7 @@ pub enum MigrationCommands {
         #[arg(long)]
         no_pin: bool,
 
+        #[arg(add = ArgValueCompleter::new(complete_migrations))]
         migration: Option<String>,
 
         /// Path to a variables file (JSON, TOML, or YAML) to use for templating.
@@ -143,6 +148,7 @@ pub enum MigrationCommands {
     /// Useful when a migration was applied manually and needs to be recorded.
     Adopt {
         /// Migration to adopt
+        #[arg(add = ArgValueCompleter::new(complete_migrations))]
         migration: Option<String>,
 
         /// Skip confirmation prompt
@@ -196,17 +202,21 @@ pub enum TestCommands {
         name: String,
     },
     Build {
+        #[arg(add = ArgValueCompleter::new(complete_tests))]
         name: String,
     },
     /// Run a particular test, or all tests if no name provided.
     Run {
+        #[arg(add = ArgValueCompleter::new(complete_tests))]
         name: Option<String>,
     },
     /// Run tests and compare to expected.  Runs all tests if no name provided.
     Compare {
+        #[arg(add = ArgValueCompleter::new(complete_tests))]
         name: Option<String>,
     },
     Expect {
+        #[arg(add = ArgValueCompleter::new(complete_tests))]
         name: String,
     },
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,103 @@
+//! Shell completion support for spawn CLI.
+//!
+//! This module provides dynamic completers for migration and test names.
+//! Completions work with any shell that supports clap_complete's CompleteEnv.
+
+use crate::config::{ConfigLoaderSaver, FolderPather, DEFAULT_CONFIG_FILE};
+use crate::store::{list_migration_fs_status, list_test_fs_status};
+use clap_complete::CompletionCandidate;
+use opendal::services::Fs;
+use opendal::Operator;
+use std::ffi::OsStr;
+
+/// Complete migration names from the migrations directory.
+///
+/// Returns all migrations (directories containing up.sql) as candidates.
+/// Filtering is left to the shell or user's fuzzy finder (e.g., fzf-tab).
+pub fn complete_migrations(_current: &OsStr) -> Vec<CompletionCandidate> {
+    list_migrations()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// Complete test names from the tests directory.
+///
+/// Returns all tests as candidates. Filtering is left to the shell.
+pub fn complete_tests(_current: &OsStr) -> Vec<CompletionCandidate> {
+    list_tests()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+/// List migrations using the existing store function.
+///
+/// Only returns directories that contain up.sql (valid migrations).
+fn list_migrations() -> Vec<String> {
+    with_runtime(|op, pather| async move {
+        list_migration_fs_status(&op, &pather, None)
+            .await
+            .map(|statuses| statuses.into_keys().collect())
+            .unwrap_or_default()
+    })
+}
+
+/// List tests using the existing store function.
+///
+/// Only returns directories that contain test.sql (valid tests).
+fn list_tests() -> Vec<String> {
+    with_runtime(|op, pather| async move {
+        list_test_fs_status(&op, &pather, None)
+            .await
+            .map(|statuses| statuses.into_keys().collect())
+            .unwrap_or_default()
+    })
+}
+
+/// Helper to run async code with a tokio runtime, operator, and pather.
+///
+/// Spins up a minimal tokio runtime and loads config to get spawn_folder.
+fn with_runtime<F, Fut>(f: F) -> Vec<String>
+where
+    F: FnOnce(Operator, FolderPather) -> Fut,
+    Fut: std::future::Future<Output = Vec<String>>,
+{
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(_) => return Vec::new(),
+    };
+
+    rt.block_on(async {
+        let service = Fs::default().root(".");
+        let op = match Operator::new(service) {
+            Ok(op) => op.finish(),
+            Err(_) => return Vec::new(),
+        };
+
+        let spawn_folder = ConfigLoaderSaver::load(DEFAULT_CONFIG_FILE, &op, None)
+            .await
+            .map(|c| c.spawn_folder)
+            .unwrap_or_else(|_| "spawn".to_string());
+
+        let pather = FolderPather { spawn_folder };
+        f(op, pather).await
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn test_complete_migrations_returns_empty_without_config() {
+        // When run from repo root without spawn.toml, should return empty
+        let result = complete_migrations(&OsString::new());
+        // Just verify it doesn't panic - result depends on working directory
+        let _ = result;
+    }
+}

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -72,7 +72,13 @@ where
     };
 
     rt.block_on(async {
-        let service = Fs::default().root(".");
+        // In tests, use static/example; in production, use current directory
+        #[cfg(test)]
+        let root = "static/example";
+        #[cfg(not(test))]
+        let root = ".";
+
+        let service = Fs::default().root(root);
         let op = match Operator::new(service) {
             Ok(op) => op.finish(),
             Err(_) => return Vec::new(),
@@ -94,10 +100,28 @@ mod tests {
     use std::ffi::OsString;
 
     #[test]
-    fn test_complete_migrations_returns_empty_without_config() {
-        // When run from repo root without spawn.toml, should return empty
+    fn test_complete_migrations() {
         let result = complete_migrations(&OsString::new());
-        // Just verify it doesn't panic - result depends on working directory
-        let _ = result;
+
+        // static/example has one migration: 20240907212659-initial
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].get_value().to_str().unwrap(),
+            "20240907212659-initial"
+        );
+    }
+
+    #[test]
+    fn test_complete_tests() {
+        let result = complete_tests(&OsString::new());
+
+        // static/example has two tests
+        assert_eq!(result.len(), 2);
+        let names: Vec<_> = result
+            .iter()
+            .map(|c| c.get_value().to_str().unwrap())
+            .collect();
+        assert!(names.contains(&"20250607115200-example-test"));
+        assert!(names.contains(&"20250607115201-example-test"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+/// Default configuration file name.
+pub const DEFAULT_CONFIG_FILE: &str = "spawn.toml";
+
 static PINFILE_LOCK_NAME: &str = "lock.toml";
 
 // 1. The "Blueprint" struct. Use this for Deserialization.

--- a/src/engine/postgres_psql.rs
+++ b/src/engine/postgres_psql.rs
@@ -550,7 +550,7 @@ impl PSQL {
 
         // Create a config to use for generating using spawn templating
         // engine.
-        let mut cfg = crate::config::Config::load("spawn.toml", &op, None)
+        let mut cfg = crate::config::Config::load(crate::config::DEFAULT_CONFIG_FILE, &op, None)
             .await
             .context("Failed to load config for postgres psql")?;
         let dbengtype = "psql".to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+pub mod completions;
 pub mod config;
 pub mod engine;
 pub mod escape;
@@ -16,6 +17,9 @@ pub mod variables;
 pub fn show_telemetry_notice() {
     eprintln!("▶ Spawn collects anonymous usage data.");
     eprintln!("  This helps us improve Spawn.");
-    eprintln!("  Set \"telemetry = false\" in spawn.toml or use DO_NOT_TRACK=1 to opt-out.");
+    eprintln!(
+        "  Set \"telemetry = false\" in {} or use DO_NOT_TRACK=1 to opt-out.",
+        config::DEFAULT_CONFIG_FILE
+    );
     eprintln!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use opendal::services::Fs;
 use opendal::Operator;
 use spawn_db::cli::{run_cli, Cli};
@@ -7,6 +7,18 @@ use spawn_db::commands::{Outcome, TelemetryDescribe};
 use spawn_db::telemetry::{self, CommandStatus, TelemetryRecorder};
 
 fn main() -> Result<()> {
+    let bin_name: &'static str = std::env::args()
+        .next()
+        .and_then(|s| {
+            std::path::Path::new(&s)
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "spawn".to_string())
+        .leak();
+
+    clap_complete::CompleteEnv::with_factory(|| Cli::command().name(bin_name)).complete();
+
     let cli = Cli::parse();
 
     // Handle internal telemetry child process (runs synchronously, no tokio runtime)

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -18,6 +18,13 @@ pub struct MigrationFileStatus {
     pub has_lock_toml: bool,
 }
 
+/// Filesystem-level status of a single test.
+#[derive(Debug, Clone)]
+pub struct TestFileStatus {
+    pub has_test_sql: bool,
+    pub has_expected: bool,
+}
+
 /// Get the filesystem status of a single migration.
 /// Returns the status indicating whether up.sql and lock.toml files exist.
 pub async fn get_migration_fs_status(
@@ -96,6 +103,60 @@ pub async fn list_migration_fs_status(
             status.has_up_sql = true;
         } else if filename == "lock.toml" {
             status.has_lock_toml = true;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Scan the tests folder and return the filesystem status of each test,
+/// keyed by test name. This does not touch the database.
+/// Performs a single recursive list for efficiency with remote storage.
+///
+/// If `test_name` is provided, only lists that specific test folder.
+/// Otherwise lists all tests.
+pub async fn list_test_fs_status(
+    op: &Operator,
+    pather: &FolderPather,
+    test_name: Option<&str>,
+) -> Result<BTreeMap<String, TestFileStatus>> {
+    let tests_folder = pather.tests_folder();
+    let normalized_folder = tests_folder
+        .trim_start_matches("./")
+        .trim_start_matches('/');
+    let tests_prefix = if let Some(name) = test_name {
+        format!("{}/{}/", normalized_folder, name)
+    } else {
+        format!("{}/", normalized_folder)
+    };
+
+    let mut lister = op
+        .lister_with(&tests_prefix)
+        .recursive(true)
+        .await
+        .context("listing tests")?;
+
+    let mut result: BTreeMap<String, TestFileStatus> = BTreeMap::new();
+
+    while let Some(entry) = lister.try_next().await? {
+        let path = entry.path().to_string();
+        let relative_path = path.strip_prefix(&tests_prefix).unwrap_or(&path);
+
+        let (name, filename) = match relative_path.split_once('/') {
+            Some((name, filename)) => (name, filename),
+            None if test_name.is_some() => (test_name.unwrap(), relative_path),
+            None => continue,
+        };
+
+        let status = result.entry(name.to_string()).or_insert(TestFileStatus {
+            has_test_sql: false,
+            has_expected: false,
+        });
+
+        if filename == "test.sql" {
+            status.has_test_sql = true;
+        } else if filename == "expected" {
+            status.has_expected = true;
         }
     }
 

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -590,7 +590,7 @@ COMMIT;"#,
     helper.adopt_migration(&adopted_migration).await?;
 
     // Create a migration but don't apply it
-    let pending_migration = helper
+    let _ = helper
         .migration_helper
         .create_migration_manual(
             "pending-migration",

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -59,7 +59,7 @@ impl MigrationTestHelper {
         op: Operator,
         config_loader: ConfigLoaderSaver,
     ) -> Result<Self> {
-        let config_path = "./spawn.toml".to_string();
+        let config_path = format!("./{}", spawn_db::config::DEFAULT_CONFIG_FILE);
         let mth = Self {
             fs: op,
             config_path,


### PR DESCRIPTION
Add completions because migrations get annoyingly long and hard to differentiate with timestamps.  Works best with fzf-tab.