### PR TITLE
throw an error if pinning a migration that doesn't exist

### DIFF
--- a/src/commands/migration/mod.rs
+++ b/src/commands/migration/mod.rs
@@ -9,7 +9,7 @@ pub use adopt::AdoptMigration;
 pub use apply::ApplyMigration;
 pub use build::BuildMigration;
 pub use new::NewMigration;
-pub use pin::PinMigration;
+pub use pin::{PinError, PinMigration};
 pub use status::MigrationStatus;
 
 pub const DEFAULT_NAMESPACE: &str = "default";

--- a/src/commands/migration/pin.rs
+++ b/src/commands/migration/pin.rs
@@ -4,6 +4,15 @@ use crate::pinfile::LockData;
 use crate::store::pinner::spawn::Spawn;
 use crate::store::pinner::Pinner;
 use anyhow::{Context, Result};
+use thiserror::Error;
+
+/// Errors specific to pin operations
+#[derive(Debug, Error)]
+pub enum PinError {
+    /// Migration folder does not exist
+    #[error("migration folder '{0}' does not exist")]
+    MigrationNotFound(String),
+}
 
 pub struct PinMigration {
     pub migration: String,
@@ -27,6 +36,17 @@ impl Command for PinMigration {
             .snapshot(config.operator())
             .await
             .context("error calling pinner snapshot")?;
+
+        // Fail if folder doesn't exist - check for the up.sql file which must exist:
+        let migration_script = config.pather().migration_script_file_path(&self.migration);
+        if !config
+            .operator()
+            .exists(&migration_script)
+            .await
+            .context("failed to check migration script")?
+        {
+            return Err(PinError::MigrationNotFound(self.migration.clone()).into());
+        }
 
         let lock_file_path = config.pather().migration_lock_file_path(&self.migration);
         let toml_str = toml::to_string_pretty(&LockData { pin: root.clone() })

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,7 +9,8 @@ pub mod test;
 pub use check::Check;
 pub use init::Init;
 pub use migration::{
-    AdoptMigration, ApplyMigration, BuildMigration, MigrationStatus, NewMigration, PinMigration,
+    AdoptMigration, ApplyMigration, BuildMigration, MigrationStatus, NewMigration, PinError,
+    PinMigration,
 };
 pub use test::{BuildTest, CompareTests, ExpectTest, NewTest, RunTest};
 

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -4,7 +4,7 @@ use opendal::services::Memory;
 use opendal::Operator;
 use pretty_assertions::assert_eq;
 use spawn_db::{
-    commands::{BuildMigration, Check, Command, NewMigration, Outcome, PinMigration},
+    commands::{BuildMigration, Check, Command, NewMigration, Outcome, PinError, PinMigration},
     config::{Config, ConfigLoaderSaver},
     engine::{CommandSpec, EngineType, TargetConfig},
     store,
@@ -446,6 +446,33 @@ async fn test_check_passes_when_all_pinned() -> Result<(), Box<dyn std::error::E
     let config = helper.load_config().await?;
     let outcome = Check.execute(&config).await?;
     assert!(matches!(outcome, Outcome::Success));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pin_fails_when_migration_does_not_exist() -> Result<(), Box<dyn std::error::Error>> {
+    let helper = MigrationTestHelper::new_empty().await?;
+
+    // Try to pin a migration that doesn't exist
+    let config = helper.load_config().await?;
+    let cmd = PinMigration {
+        migration: "nonexistent-migration".to_string(),
+    };
+
+    let Err(err) = cmd.execute(&config).await else {
+        panic!("Pinning a non-existent migration should fail");
+    };
+
+    // Check that the error is the specific PinError::MigrationNotFound type
+    let pin_error = err
+        .downcast_ref::<PinError>()
+        .expect("Error should be a PinError");
+    assert!(
+        matches!(pin_error, PinError::MigrationNotFound(_)),
+        "Expected PinError::MigrationNotFound, got: {:?}",
+        pin_error
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Currently if you try to pin a migration that doesn't exist, it creates the folder.  We should throw an error instead.