### PR TITLE
fix up not creating files for pin when migration does not exist

### DIFF
--- a/src/commands/migration/pin.rs
+++ b/src/commands/migration/pin.rs
@@ -26,6 +26,17 @@ impl TelemetryDescribe for PinMigration {
 
 impl Command for PinMigration {
     async fn execute(&self, config: &Config) -> Result<Outcome> {
+        // Fail early if migration doesn't exist - check for the up.sql file which must exist:
+        let migration_script = config.pather().migration_script_file_path(&self.migration);
+        if !config
+            .operator()
+            .exists(&migration_script)
+            .await
+            .context("failed to check migration script")?
+        {
+            return Err(PinError::MigrationNotFound(self.migration.clone()).into());
+        }
+
         let mut pinner = Spawn::new(
             config.pather().pinned_folder(),
             config.pather().components_folder(),
@@ -36,17 +47,6 @@ impl Command for PinMigration {
             .snapshot(config.operator())
             .await
             .context("error calling pinner snapshot")?;
-
-        // Fail if folder doesn't exist - check for the up.sql file which must exist:
-        let migration_script = config.pather().migration_script_file_path(&self.migration);
-        if !config
-            .operator()
-            .exists(&migration_script)
-            .await
-            .context("failed to check migration script")?
-        {
-            return Err(PinError::MigrationNotFound(self.migration.clone()).into());
-        }
 
         let lock_file_path = config.pather().migration_lock_file_path(&self.migration);
         let toml_str = toml::to_string_pretty(&LockData { pin: root.clone() })

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -208,6 +208,23 @@ impl MigrationTestHelper {
 
         Ok(())
     }
+
+    /// Collect all files and their contents as a map for comparison
+    pub async fn collect_all_files(&self) -> Result<HashMap<String, Vec<u8>>> {
+        let mut lister = self.fs.lister_with("/").recursive(true).await?;
+        let mut files = HashMap::new();
+
+        while let Some(entry) = lister.try_next().await? {
+            // Skip directories
+            if entry.path().ends_with('/') {
+                continue;
+            }
+            let file_data = self.fs.read(entry.path()).await?.to_bytes().to_vec();
+            files.insert(entry.path().to_string(), file_data);
+        }
+
+        Ok(files)
+    }
 }
 
 // Run a create migration test:
@@ -454,8 +471,20 @@ async fn test_check_passes_when_all_pinned() -> Result<(), Box<dyn std::error::E
 async fn test_pin_fails_when_migration_does_not_exist() -> Result<(), Box<dyn std::error::Error>> {
     let helper = MigrationTestHelper::new_empty().await?;
 
-    // Try to pin a migration that doesn't exist
+    // Add a component so that pinning would create files if it ran
     let config = helper.load_config().await?;
+    helper
+        .fs
+        .write(
+            &format!("{}/example.sql", config.pather().components_folder()),
+            "SELECT 1;",
+        )
+        .await?;
+
+    // Capture files before attempting to pin
+    let files_before = helper.collect_all_files().await?;
+
+    // Try to pin a migration that doesn't exist
     let cmd = PinMigration {
         migration: "nonexistent-migration".to_string(),
     };
@@ -472,6 +501,13 @@ async fn test_pin_fails_when_migration_does_not_exist() -> Result<(), Box<dyn st
         matches!(pin_error, PinError::MigrationNotFound(_)),
         "Expected PinError::MigrationNotFound, got: {:?}",
         pin_error
+    );
+
+    // Verify no files were created or modified
+    let files_after = helper.collect_all_files().await?;
+    assert_eq!(
+        files_before, files_after,
+        "No files should be created or modified when pinning fails"
     );
 
     Ok(())

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -483,6 +483,14 @@ async fn test_pin_fails_when_migration_does_not_exist() -> Result<(), Box<dyn st
 
     // Capture files before attempting to pin
     let files_before = helper.collect_all_files().await?;
+    let component_path = format!("{}/example.sql", config.pather().components_folder());
+    // Strip leading slash since collect_all_files returns paths without it
+    let component_path = component_path.trim_start_matches('/');
+    assert!(
+        files_before.contains_key(component_path),
+        "Component file should exist at {}",
+        component_path
+    );
 
     // Try to pin a migration that doesn't exist
     let cmd = PinMigration {


### PR DESCRIPTION
previous PR didn't exit early enough so that pinned files would be created, just lock file not created.