### PR TITLE
secrets implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ cargo test test_name -- --ignored --nocapture         # Single integration test 
 ## Architecture Notes
 
 - **Engine trait** (`src/engine/mod.rs`): Async trait for database operations. Currently only `PSQL` (postgres via psql CLI). Migration apply uses two separate psql sessions: one runs the migration, the second records the outcome (success or failure) to `_spawn.migration_history`.
-- **Streaming**: Templates render directly to a writer (piped to psql stdin) without materialising the full SQL in memory. A `TeeWriter` computes checksums during streaming.
+- **Streaming**: Templates render directly to a writer (piped to psql stdin) without materialising the full SQL in memory. The `migration_history.checksum` audit-trail fingerprint is a hash of the migration's raw (unrendered) template source (`StreamingGeneration::raw_checksum`), computed separately from the streamed render — never the rendered/executed SQL, since that may contain resolved secret values.
 - **Advisory locking**: Prevents concurrent migration application via `pg_try_advisory_lock`.
 - **Command pattern**: Each CLI command is a struct implementing `Command` trait with `execute(&self, config) -> Result<Outcome>`.
 - **Storage**: Uses `opendal::Operator` for filesystem abstraction. Tests use in-memory operators.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
               label: "Local Spawn Development",
               slug: "guides/local-development",
             },
+            { label: "Managing Secrets", slug: "guides/secrets" },
           ],
         },
         {

--- a/docs/src/components/cli-options.ts
+++ b/docs/src/components/cli-options.ts
@@ -36,3 +36,12 @@ export const variablesOption: CLIOption[] = [
       "Path to variables file (JSON, TOML, or YAML). Values are available in templates under {{ variables }}.",
   },
 ];
+
+/** The --reveal-secrets flag used by build commands, which mask secret() values by default. */
+export const revealSecretsOption: CLIOption[] = [
+  {
+    flag: "--reveal-secrets",
+    description:
+      "Render real secret() values instead of masked placeholders. For local debugging only — build output is not executed.",
+  },
+];

--- a/docs/src/content/docs/cli/migration-apply.mdx
+++ b/docs/src/content/docs/cli/migration-apply.mdx
@@ -51,7 +51,9 @@ Shows a list of pending migrations and prompts for confirmation before applying 
 
 ## Pin requirement
 
-By default, `apply` requires migrations to have a `lock.toml`. This ensures the exact same component versions are used every time. Use `--no-pin` to bypass this requirement and use current working tree components (not recommended for production).
+By default, `apply` requires migrations to have a `lock.toml`. This ensures the exact same component versions are used every time. Use `--no-pin` to bypass this requirement and use current working tree components — **not recommended**, and never for production applies.
+
+With `--no-pin`, the `pin_hash` recorded to the audit trail is computed by walking the current component tree in a pass separate from the actual template render. If a component file on disk changes between (or during) those two passes, the recorded `pin_hash` can end up not matching what was actually rendered and executed. Only a pinned migration guarantees the components used are exactly the ones snapshotted in `lock.toml`, immune to concurrent edits — always apply pinned migrations in any shared or production environment.
 
 ## Secrets
 

--- a/docs/src/content/docs/cli/migration-apply.mdx
+++ b/docs/src/content/docs/cli/migration-apply.mdx
@@ -53,6 +53,10 @@ Shows a list of pending migrations and prompts for confirmation before applying 
 
 By default, `apply` requires migrations to have a `lock.toml`. This ensures the exact same component versions are used every time. Use `--no-pin` to bypass this requirement and use current working tree components (not recommended for production).
 
+## Secrets
+
+`apply` always reveals real `secret()` values, since it executes the rendered SQL against the database. See the [Secrets guide](/guides/secrets/) for how secrets are configured and how other commands mask them for inspection.
+
 ## Retry logic
 
 If a migration previously failed, `apply` will refuse to run it again unless you pass `--retry`. This prevents accidental re-execution of partially applied migrations. Retrying a successful migration will run the same migration again.

--- a/docs/src/content/docs/cli/migration-build.mdx
+++ b/docs/src/content/docs/cli/migration-build.mdx
@@ -9,13 +9,15 @@ import {
   targetOption,
   environmentOption,
   variablesOption,
+  revealSecretsOption,
 } from "../../../components/cli-options";
 
 <CLICommand
-  usage="spawn migration build <migration> [--pinned] [--variables <path>]"
+  usage="spawn migration build <migration> [--pinned] [--variables <path>] [--reveal-secrets]"
   options={[
     { flag: "--pinned", description: "Use pinned component versions from lock.toml" },
     ...variablesOption,
+    ...revealSecretsOption,
     ...environmentOption,
     ...targetOption,
     ...globalOptions
@@ -37,6 +39,10 @@ Renders a migration's `up.sql` template into final SQL, resolving component incl
 
 Without `--pinned`, the migration uses the current working tree versions of components. With `--pinned`, it uses the locked versions from the migration's `lock.toml`.
 
+## Secrets
+
+Any `secret()` calls in the template are masked by default (e.g. `***MASKED:name***`); pass `--reveal-secrets` to render real values for local debugging. `migration apply` always reveals real values, since it actually runs the SQL. See the [Secrets guide](/guides/secrets/#masking) for full details, including why a masked build still verifies each secret is reachable.
+
 ## Examples
 
 Build with current components:
@@ -55,6 +61,12 @@ Build with custom variables:
 
 ```bash
 spawn migration build 20260131120000-add-users-table --variables ./prod-vars.json
+```
+
+Build and show real secret values for debugging:
+
+```bash
+spawn migration build 20260131120000-add-users-table --reveal-secrets
 ```
 
 </CLICommand>

--- a/docs/src/content/docs/cli/migration-pin.mdx
+++ b/docs/src/content/docs/cli/migration-pin.mdx
@@ -36,6 +36,10 @@ Pinning ensures migrations are reproducible:
 3. Stores snapshots in `pinned/<hash>/`
 4. Creates `lock.toml` in the migration directory
 
+## Integrity
+
+Every file read back from `pinned/` has its content hash recomputed and checked against the hash implied by its path. If a pinned file's contents were ever modified (or corrupted) on disk after pinning, the mismatch is detected and the build/apply fails loudly rather than silently using the altered content.
+
 ## Example
 
 ```bash

--- a/docs/src/content/docs/cli/test-build.mdx
+++ b/docs/src/content/docs/cli/test-build.mdx
@@ -33,7 +33,7 @@ Similar to [`spawn migration build`](/cli/migration-build/), but for tests. Proc
 
 ## Secrets
 
-Any `secret()` calls are masked by default; pass `--reveal-secrets` to render real values for local debugging. `test run`/`test compare`/`test expect` always reveal real values, since they execute against a real database. See the [Secrets guide](/guides/secrets/#masking) for full details, including why a masked build still verifies each secret is reachable.
+Any `secret()` calls are masked by default; pass `--reveal-secrets` to render real values for local debugging. `test run`/`test compare`/`test expect` always mask values so secrets cannot be printed, diffed, or persisted in expected output. See the [Secrets guide](/guides/secrets/#masking) for full details, including why a masked build still verifies each secret is reachable.
 
 ## Examples
 

--- a/docs/src/content/docs/cli/test-build.mdx
+++ b/docs/src/content/docs/cli/test-build.mdx
@@ -7,12 +7,18 @@ import CLICommand from "../../../components/CLICommand.astro";
 import {
   globalOptions,
   targetOption,
+  environmentOption,
   revealSecretsOption,
 } from "../../../components/cli-options";
 
 <CLICommand
   usage="spawn test build <name> [--reveal-secrets]"
-  options={[...revealSecretsOption, ...targetOption, ...globalOptions]}
+  options={[
+    ...revealSecretsOption,
+    ...environmentOption,
+    ...targetOption,
+    ...globalOptions,
+  ]}
 >
 
 Renders a test's `test.sql` template into final SQL, resolving component includes and template variables. Outputs to stdout.

--- a/docs/src/content/docs/cli/test-build.mdx
+++ b/docs/src/content/docs/cli/test-build.mdx
@@ -4,11 +4,15 @@ description: Build a test into final SQL.
 ---
 
 import CLICommand from "../../../components/CLICommand.astro";
-import { globalOptions, targetOption } from "../../../components/cli-options";
+import {
+  globalOptions,
+  targetOption,
+  revealSecretsOption,
+} from "../../../components/cli-options";
 
 <CLICommand
-  usage="spawn test build <name>"
-  options={[...targetOption, ...globalOptions]}
+  usage="spawn test build <name> [--reveal-secrets]"
+  options={[...revealSecretsOption, ...targetOption, ...globalOptions]}
 >
 
 Renders a test's `test.sql` template into final SQL, resolving component includes and template variables. Outputs to stdout.
@@ -21,10 +25,18 @@ Renders a test's `test.sql` template into final SQL, resolving component include
 
 Similar to [`spawn migration build`](/cli/migration-build/), but for tests. Processes the `test.sql` template and resolves any component includes or template logic.
 
-## Example
+## Secrets
+
+Any `secret()` calls are masked by default; pass `--reveal-secrets` to render real values for local debugging. `test run`/`test compare`/`test expect` always reveal real values, since they execute against a real database. See the [Secrets guide](/guides/secrets/#masking) for full details, including why a masked build still verifies each secret is reachable.
+
+## Examples
 
 ```bash
 spawn test build user-creation
+```
+
+```bash
+spawn test build user-creation --reveal-secrets
 ```
 
 </CLICommand>

--- a/docs/src/content/docs/cli/test-compare.mdx
+++ b/docs/src/content/docs/cli/test-compare.mdx
@@ -4,11 +4,15 @@ description: Run tests and compare output to expected results.
 ---
 
 import CLICommand from "../../../components/CLICommand.astro";
-import { globalOptions, targetOption } from "../../../components/cli-options";
+import {
+  globalOptions,
+  targetOption,
+  environmentOption,
+} from "../../../components/cli-options";
 
 <CLICommand
   usage="spawn test compare <name>"
-  options={[...targetOption, ...globalOptions]}
+  options={[...environmentOption, ...targetOption, ...globalOptions]}
 >
 
 Runs tests and compares their output against saved expected results, reporting any differences.

--- a/docs/src/content/docs/cli/test-compare.mdx
+++ b/docs/src/content/docs/cli/test-compare.mdx
@@ -27,6 +27,10 @@ For each test:
 
 Use [`spawn test expect`](/cli/test-expect/) to update the expected output.
 
+## Secrets
+
+`test compare` runs the test for real, so it always reveals real `secret()` values. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+
 ## Example
 
 ```bash

--- a/docs/src/content/docs/cli/test-compare.mdx
+++ b/docs/src/content/docs/cli/test-compare.mdx
@@ -33,7 +33,7 @@ Use [`spawn test expect`](/cli/test-expect/) to update the expected output.
 
 ## Secrets
 
-`test compare` runs the test for real, so it always reveals real `secret()` values. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+`test compare` always masks `secret()` values so real secrets cannot appear in test output or diffs. See the [Secrets guide](/guides/secrets/#masking) for details.
 
 ## Example
 

--- a/docs/src/content/docs/cli/test-expect.mdx
+++ b/docs/src/content/docs/cli/test-expect.mdx
@@ -4,11 +4,15 @@ description: Update expected test output.
 ---
 
 import CLICommand from "../../../components/CLICommand.astro";
-import { globalOptions, targetOption } from "../../../components/cli-options";
+import {
+  globalOptions,
+  targetOption,
+  environmentOption,
+} from "../../../components/cli-options";
 
 <CLICommand
   usage="spawn test expect <name>"
-  options={[...targetOption, ...globalOptions]}
+  options={[...environmentOption, ...targetOption, ...globalOptions]}
 >
 
 Runs a test and saves its output as the new expected result for future comparisons.

--- a/docs/src/content/docs/cli/test-expect.mdx
+++ b/docs/src/content/docs/cli/test-expect.mdx
@@ -25,6 +25,10 @@ Runs a test and saves its output as the new expected result for future compariso
 
 Use this command when test behavior changes intentionally and you want to update the baseline for [`spawn test compare`](/cli/test-compare/).
 
+## Secrets
+
+`test expect` runs the test for real, so it always reveals real `secret()` values — the saved `expected` file will contain real secret values if the test outputs them. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+
 ## Example
 
 ```bash

--- a/docs/src/content/docs/cli/test-expect.mdx
+++ b/docs/src/content/docs/cli/test-expect.mdx
@@ -31,7 +31,7 @@ Use this command when test behavior changes intentionally and you want to update
 
 ## Secrets
 
-`test expect` runs the test for real, so it always reveals real `secret()` values — the saved `expected` file will contain real secret values if the test outputs them. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+`test expect` always masks `secret()` values so real secrets cannot be written into the saved `expected` file. See the [Secrets guide](/guides/secrets/#masking) for details.
 
 ## Example
 

--- a/docs/src/content/docs/cli/test-new.mdx
+++ b/docs/src/content/docs/cli/test-new.mdx
@@ -4,11 +4,15 @@ description: Create a new test.
 ---
 
 import CLICommand from "../../../components/CLICommand.astro";
-import { globalOptions, targetOption } from "../../../components/cli-options";
+import {
+  globalOptions,
+  targetOption,
+  environmentOption,
+} from "../../../components/cli-options";
 
 <CLICommand
   usage="spawn test new <name>"
-  options={[...targetOption, ...globalOptions]}
+  options={[...environmentOption, ...targetOption, ...globalOptions]}
 >
 
 Creates a new test directory with a template `test.sql` file.

--- a/docs/src/content/docs/cli/test-run.mdx
+++ b/docs/src/content/docs/cli/test-run.mdx
@@ -4,11 +4,15 @@ description: Run tests against the database.
 ---
 
 import CLICommand from "../../../components/CLICommand.astro";
-import { globalOptions, targetOption } from "../../../components/cli-options";
+import {
+  globalOptions,
+  targetOption,
+  environmentOption,
+} from "../../../components/cli-options";
 
 <CLICommand
   usage="spawn test run <name>"
-  options={[...targetOption, ...globalOptions]}
+  options={[...environmentOption, ...targetOption, ...globalOptions]}
 >
 
 Executes one or all tests against the configured database and displays the results.

--- a/docs/src/content/docs/cli/test-run.mdx
+++ b/docs/src/content/docs/cli/test-run.mdx
@@ -21,6 +21,10 @@ Executes one or all tests against the configured database and displays the resul
 
 Runs the SQL for the test against the database, showing the output from that test.
 
+## Secrets
+
+`test run` always reveals real `secret()` values, since it executes the rendered SQL against the database. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+
 ## Examples
 
 Run a specific test:

--- a/docs/src/content/docs/cli/test-run.mdx
+++ b/docs/src/content/docs/cli/test-run.mdx
@@ -27,7 +27,7 @@ Runs the SQL for the test against the database, showing the output from that tes
 
 ## Secrets
 
-`test run` always reveals real `secret()` values, since it executes the rendered SQL against the database. See the [Secrets guide](/guides/secrets/) for how secrets are configured.
+`test run` always masks `secret()` values, even though it executes the rendered SQL against the database, so secrets cannot leak through test output. See the [Secrets guide](/guides/secrets/#masking) for details.
 
 ## Examples
 

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -1,0 +1,75 @@
+---
+title: Managing Secrets
+description: Use passwords and other secrets in Spawn templates.
+---
+
+Spawn migrations sometimes need real secrets — a password for a role being created, an API key seeded into a config table, and so on. The `[secrets]` table in `spawn.toml` declares where each secret comes from, and the `secret()` template function reads it at render time, so real values never need to be committed to your repo as plain [variables](/reference/templating/#variables).
+
+## Defining secrets
+
+Each secret has a `default` source, and optional per-environment overrides keyed by the same environment names used by `[targets.*].environment`:
+
+```toml
+[secrets.application_password.default]
+source = "file"
+path = "/run/secrets/application-password"
+
+[secrets.application_password.environments.dev]
+source = "file"
+path = "./local-secrets/application-password.txt"
+```
+
+When a template calls `secret("application_password")`, Spawn looks up `environments.<current environment>` first, falling back to `default` if there's no override for the current environment. `default` is required — there's no implicit "no secret configured" fallback, so pick a `default` that's safe for production and override it for looser environments like `dev`.
+
+See the [configuration reference](/reference/config/#secrets) for the exact fields of every `source` type.
+
+## Choosing a source
+
+There are four ways to tell Spawn where a secret's value actually lives:
+
+- **`env`** reads an OS environment variable — the natural fit when a secret is already injected that way, e.g. by a CI/CD pipeline or a container orchestrator's own secret injection.
+- **`file`** reads a file's contents. Covers Docker/Kubernetes secrets mounted under `/run/secrets`, systemd's `LoadCredential=`, or an already-decrypted `sops`/`gpg` output file.
+- **`command`** runs a command and uses its trimmed stdout as the value.
+- **`literal`** is an inline value in `spawn.toml`, gated behind an explicit `insecure = true` flag.
+
+`command` is a general-purpose escape hatch, and most secret managers ship a CLI that can print a value to stdout, so Vault, 1Password, AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, Doppler, Bitwarden, `pass`, and `systemd-creds` are all reachable this way without Spawn needing a dedicated integration for each one:
+
+```toml
+[secrets.application_password.default]
+source = "command"
+command = ["op", "read", "op://vault/application-password/password"]
+```
+
+`literal` is not intended to be used for production and therefore has a `insecure` flag to ensure the user understands that this is not for production use. Spawn refuses to use a `literal` secret without it, so a plaintext value committed to `spawn.toml` can't accidentally become a project's "secure default." Reach for it only as a `dev`/local override, never as a `default`:
+
+```toml
+[secrets.application_password.environments.dev]
+source = "literal"
+value = "dev-only-password"
+insecure = true
+```
+
+## Using `secret()` in templates
+
+```sql
+CREATE ROLE app_user WITH LOGIN PASSWORD {{ secret("application_password") }};
+```
+
+An unresolvable secret (missing environment variable, missing file, failing command, a `literal` without `insecure = true`, or a name not defined in `spawn.toml`) fails the render rather than silently producing an empty value. A secret referenced more than once in the same render resolves to the same value, even if its source (e.g. a `command`) isn't deterministic.
+
+## Masking
+
+Whether `secret()` returns the real value or a placeholder like `***MASKED:application_password***` depends on the command being run, not on anything in your template or config:
+
+| Command                                                                                                | Secrets                                                                            |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| [`migration apply`](/cli/migration-apply/)                                                             | Always revealed — it executes the rendered SQL for real.                           |
+| [`migration build`](/cli/migration-build/)                                                             | Masked by default. Pass `--reveal-secrets` to see real values for local debugging. |
+| [`test run`](/cli/test-run/), [`test compare`](/cli/test-compare/), [`test expect`](/cli/test-expect/) | Always revealed — they execute the rendered SQL against a real database.           |
+| [`test build`](/cli/test-build/)                                                                       | Masked by default. Pass `--reveal-secrets` to see real values for local debugging. |
+
+Masking only affects the value _returned to the template_ — the secret is still fully resolved either way, so a masked `build` still fails if the secret is unreachable or misconfigured (including the `literal`/`insecure` check above). It just never displays the real value. This means `build` doubles as a way to verify your secrets are reachable in a given environment before you ever run `apply`.
+
+## Secrets and pinning
+
+Secrets are entirely outside of [pinning](/cli/migration-pin/): `spawn migration pin` snapshots component _content_ into the content-addressed store and records it in a migration's `lock.toml`. It never touches `[secrets]` or resolved secret values — a secret's source is declared once in `spawn.toml`, and its value is re-resolved fresh every time a migration is built or applied, regardless of pinning.

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -67,11 +67,12 @@ Whether `secret()` returns the real value or a placeholder like `***MASKED:appli
 | Command                                                                                                | Secrets                                                                            |
 | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | [`migration apply`](/cli/migration-apply/)                                                             | Always revealed — it executes the rendered SQL for real.                           |
-| [`migration build`](/cli/migration-build/)                                                             | Masked by default. Pass `--reveal-secrets` to see real values for local debugging. |
-| [`test run`](/cli/test-run/), [`test compare`](/cli/test-compare/), [`test expect`](/cli/test-expect/) | Always revealed — they execute the rendered SQL against a real database.           |
-| [`test build`](/cli/test-build/)                                                                       | Masked by default. Pass `--reveal-secrets` to see real values for local debugging. |
+| [`migration build`](/cli/migration-build/), [`test build`](/cli/test-build/)                           | Masked by default. Pass `--reveal-secrets` to see real values for local debugging. |
+| [`test run`](/cli/test-run/), [`test compare`](/cli/test-compare/), [`test expect`](/cli/test-expect/) | Always masked, with no way to reveal — see below.                                  |
 
 Masking only affects the value _returned to the template_ — the secret is still fully resolved either way, so a masked `build` still fails if the secret is unreachable or misconfigured (including the `literal`/`insecure` check above). It just never displays the real value. This means `build` doubles as a way to verify your secrets are reachable in a given environment before you ever run `apply`.
+
+`test run`/`compare`/`expect` mask unconditionally, with no `--reveal-secrets` equivalent: unlike a terminal or a CI log, their output is diffed against — and, via `test expect`, written into — an `expected` file that gets committed to the repo. A revealed secret there wouldn't just risk a transient leak (e.g. a failing statement's diagnostics echoing it back); it would be permanently baked into git history the first time a test happened to touch it. If you need a test that depends on a secret's real value, that's a real limitation today — there's no per-test override, since a use case for one hasn't come up yet. Please open an issue outlining your use case, so that we can understand better why this might be needed and therefore how to provide it.
 
 ## Secrets in failed applies
 

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -71,6 +71,18 @@ Whether `secret()` returns the real value or a placeholder like `***MASKED:appli
 
 Masking only affects the value _returned to the template_ — the secret is still fully resolved either way, so a masked `build` still fails if the secret is unreachable or misconfigured (including the `literal`/`insecure` check above). It just never displays the real value. This means `build` doubles as a way to verify your secrets are reachable in a given environment before you ever run `apply`.
 
+## Secrets in failed applies
+
+`migration apply` executes real SQL, and a failing statement can make the database echo a literal value back in its own error message — a unique or check constraint violation reporting the row's actual contents, an `invalid input syntax` error quoting the offending value, and so on. If that statement used `secret()`, the real value could otherwise end up in whatever captures `apply`'s output — a terminal, a CI log, anything.
+
+To prevent this, Spawn replaces every secret value a failed `apply` actually resolved with `***REDACTED***` in the returned error, before it's ever displayed or logged.
+
+:::caution[This is a best-effort substitution, not a guarantee]
+The redaction works by matching the exact resolved value against the error text — it can't distinguish a secret's value from unrelated text that happens to be identical. That has one real consequence worth knowing: someone who can both **author** migrations and **apply** them against a target database could, in principle, deliberately craft a migration to test whether a guessed string matches a currently configured secret — by embedding the guess somewhere designed to fail, applying it, and checking whether the guess comes back redacted.
+
+This is meaningfully harder to exploit than reading a log: it requires apply access to the actual database, not just read access to `_spawn.migration_history`, and each guess is a real, visible, failed apply rather than a silent offline check. But it means this mechanism is a defense against **accidental** disclosure (an ordinary failing migration leaking a value into CI logs), not a substitute for controlling who can author and apply migrations against sensitive targets.
+:::
+
 ## Secrets and pinning
 
 Secrets are entirely outside of [pinning](/cli/migration-pin/): `spawn migration pin` snapshots component _content_ into the content-addressed store and records it in a migration's `lock.toml`. It never touches `[secrets]` or resolved secret values — a secret's source is declared once in `spawn.toml`, and its value is re-resolved fresh every time a migration is built or applied, regardless of pinning.

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -11,7 +11,7 @@ Each secret has a `default` source, and optional per-environment overrides keyed
 
 ```toml
 [secrets.application_password.default]
-source = "file"
+source = "host_file"
 path = "/run/secrets/application-password"
 
 [secrets.application_password.environments.dev]
@@ -25,10 +25,11 @@ See the [configuration reference](/reference/config/#secrets) for the exact fiel
 
 ## Choosing a source
 
-There are four ways to tell Spawn where a secret's value actually lives:
+There are five ways to tell Spawn where a secret's value actually lives:
 
 - **`env`** reads an OS environment variable — the natural fit when a secret is already injected that way, e.g. by a CI/CD pipeline or a container orchestrator's own secret injection.
-- **`file`** reads a file's contents. Covers Docker/Kubernetes secrets mounted under `/run/secrets`, systemd's `LoadCredential=`, or an already-decrypted `sops`/`gpg` output file.
+- **`file`** reads a file via spawn's configured operator, resolved the same way any other file spawn reads is. For now, this is restricted to the project's path.
+- **`host_file`** reads a file directly from the host filesystem, bypassing the operator. Use this for secrets mounted on the host outside spawn's storage — Docker/Kubernetes secrets under `/run/secrets`, systemd's `LoadCredential=`, or an already-decrypted `sops`/`gpg` output file. This is the one to use whenever the path is a real absolute host path.
 - **`command`** runs a command and uses its trimmed stdout as the value.
 - **`literal`** is an inline value in `spawn.toml`, gated behind an explicit `insecure = true` flag.
 

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -41,6 +41,8 @@ source = "command"
 command = ["op", "read", "op://vault/application-password/password"]
 ```
 
+If a `command` source fails, Spawn never learns its value — so unlike every other secret-disclosure path, that value can't be found and redacted afterwards. To guard against a provider script that logs its own inputs on failure (e.g. `echo "got: $PASSWORD" >&2; exit 1`), a failed command's stderr is not shown by default — only its exit code. Set `SPAWN_DEBUG_COMMAND_STDERR=1` to see the real stderr for local debugging. Never set this in CI or anywhere output may be logged or shared, since that's exactly what the default behavior protects against.
+
 `literal` is not intended to be used for production and therefore has an `insecure` flag to ensure the user understands that this is not for production use. Spawn refuses to use a `literal` secret without it, so a plaintext value committed to `spawn.toml` can't accidentally become a project's "secure default." Reach for it only as a `dev`/local override, never as a `default`:
 
 ```toml

--- a/docs/src/content/docs/guides/secrets.md
+++ b/docs/src/content/docs/guides/secrets.md
@@ -40,7 +40,7 @@ source = "command"
 command = ["op", "read", "op://vault/application-password/password"]
 ```
 
-`literal` is not intended to be used for production and therefore has a `insecure` flag to ensure the user understands that this is not for production use. Spawn refuses to use a `literal` secret without it, so a plaintext value committed to `spawn.toml` can't accidentally become a project's "secure default." Reach for it only as a `dev`/local override, never as a `default`:
+`literal` is not intended to be used for production and therefore has an `insecure` flag to ensure the user understands that this is not for production use. Spawn refuses to use a `literal` secret without it, so a plaintext value committed to `spawn.toml` can't accidentally become a project's "secure default." Reach for it only as a `dev`/local override, never as a `default`:
 
 ```toml
 [secrets.application_password.environments.dev]

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -254,7 +254,7 @@ Each secret has a `default` source and optional per-environment overrides, keyed
 
 ```toml
 [secrets.application_password.default]
-source = "file"
+source = "host_file"
 path = "/run/secrets/application-password"
 
 [secrets.application_password.environments.dev]
@@ -278,11 +278,21 @@ name = "APPLICATION_PASSWORD"
 
 #### `file`
 
-Reads the contents of a file, with any trailing newline stripped.
+Reads a file via spawn's configured operator, with any trailing newline stripped — resolved the same way any other file spawn reads is (`read_file`, migration/component lookups, etc.). It is **not** a real filesystem path, so an absolute path here will not reach a real host location — use `host_file` for that.
+
+```toml
+[secrets.application_password.environments.dev]
+source = "file"
+path = "./local-secrets/application-password.txt"
+```
+
+#### `host_file`
+
+Reads a file directly from the host filesystem, bypassing the operator, with any trailing newline stripped. Use this for secrets mounted on the host outside spawn's storage — Docker/Kubernetes secrets under `/run/secrets`, systemd's `LoadCredential=`, or an already-decrypted `sops`/`gpg` output file.
 
 ```toml
 [secrets.application_password.default]
-source = "file"
+source = "host_file"
 path = "/run/secrets/application-password"
 ```
 

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -130,6 +130,13 @@ telemetry = false
 
 Set the `DO_NOT_TRACK` environment variable to disable telemetry globally.
 
+### `secrets`
+
+**Type:** Table  
+**Required:** No
+
+Named secrets available to templates via the [`secret()`](/reference/templating/#secret) function. See [Secrets](#secrets) below for the field format, and the [Secrets guide](/guides/secrets/) for how they're used in templates and which commands reveal vs. mask them.
+
 ## Target configurations
 
 The `[targets]` section defines one or more database connections. Each target is a table with the following fields. For practical setup examples including Docker and Google Cloud SQL, see the [Database Connections guide](/guides/manage-databases/).
@@ -238,6 +245,69 @@ command = {
 ```
 
 The `--dry-run` flag makes `gcloud` output the SSH command as a string instead of executing it.
+
+## Secrets
+
+The `[secrets]` table defines values that templates can read via the [`secret()`](/reference/templating/#secret) function, so passwords and other sensitive values don't need to be committed as plain template variables. See the [Secrets guide](/guides/secrets/) for how secrets are used in templates and which commands reveal vs. mask them; this section covers the `spawn.toml` field format.
+
+Each secret has a `default` source and optional per-environment overrides, keyed by the same environment names used by `[targets.*].environment`.
+
+```toml
+[secrets.application_password.default]
+source = "file"
+path = "/run/secrets/application-password"
+
+[secrets.application_password.environments.dev]
+source = "file"
+path = "./local-secrets/application-password.txt"
+```
+
+When a template calls `secret("application_password")`, Spawn looks up `environments.<current environment>` first, falling back to `default` if there's no override for the current environment. `default` is required — there's no implicit "no secret configured" fallback.
+
+### Sources
+
+#### `env`
+
+Reads an OS environment variable.
+
+```toml
+[secrets.application_password.default]
+source = "env"
+name = "APPLICATION_PASSWORD"
+```
+
+#### `file`
+
+Reads the contents of a file, with any trailing newline stripped.
+
+```toml
+[secrets.application_password.default]
+source = "file"
+path = "/run/secrets/application-password"
+```
+
+#### `command`
+
+Runs a command and uses its trimmed stdout as the value. Useful for secret managers with a CLI (Vault, 1Password, `sops`, `systemd-creds`, etc.).
+
+```toml
+[secrets.application_password.default]
+source = "command"
+command = ["op", "read", "op://vault/application-password/password"]
+```
+
+#### `literal`
+
+An inline value. Requires `insecure = true` — Spawn refuses to use a `literal` secret without it, so a plaintext value committed to `spawn.toml` can't accidentally become a project's "secure default". This is enforced whenever the secret is resolved (including a masked `migration build`), not just when it's actually displayed. Intended for local development only.
+
+```toml
+[secrets.application_password.environments.dev]
+source = "literal"
+value = "dev-only-password"
+insecure = true
+```
+
+See [Secrets: Masking](/guides/secrets/#masking) for which commands reveal real values vs. mask them.
 
 ## Complete example
 

--- a/docs/src/content/docs/reference/templating.md
+++ b/docs/src/content/docs/reference/templating.md
@@ -142,6 +142,16 @@ Generates a time-ordered UUID v7 string.
 INSERT INTO events (id, type) VALUES ({{ gen_uuid_v7() }}, 'user_created');
 ```
 
+### `secret`
+
+Resolves a named secret defined in the `[secrets]` table of `spawn.toml`.
+
+```sql
+CREATE ROLE app_user WITH LOGIN PASSWORD {{ secret("application_password") }};
+```
+
+See the [Secrets guide](/guides/secrets/) for how to define sources (environment variable, file, command, or an explicit `insecure` literal), per-environment overrides, and which commands reveal real values vs. mask them.
+
 ## Filters
 
 Filters transform values in template expressions. Minijinja provides many built-in filters like `upper`, `default`, and `length` — see the [Minijinja filters documentation](https://docs.rs/minijinja/latest/minijinja/filters/index.html) for the complete list.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,6 +127,11 @@ pub enum MigrationCommands {
         /// Overrides the variables_file setting in spawn.toml.
         #[arg(long)]
         variables: Option<String>,
+
+        /// Render real secret() values instead of masked placeholders.
+        /// Intended for local debugging only; build output is not executed.
+        #[arg(long)]
+        reveal_secrets: bool,
     },
     /// Apply will apply this migration to the database if not already applied,
     /// or all migrations if called without argument.
@@ -181,10 +186,14 @@ impl TelemetryDescribe for MigrationCommands {
             MigrationCommands::New { .. } => TelemetryInfo::new("new"),
             MigrationCommands::Pin { .. } => TelemetryInfo::new("pin"),
             MigrationCommands::Build {
-                pinned, variables, ..
+                pinned,
+                variables,
+                reveal_secrets,
+                ..
             } => TelemetryInfo::new("build").with_properties(vec![
                 ("opt_pinned", pinned.to_string()),
                 ("has_variables", variables.is_some().to_string()),
+                ("opt_reveal_secrets", reveal_secrets.to_string()),
             ]),
             MigrationCommands::Apply {
                 no_pin,
@@ -235,6 +244,11 @@ pub enum TestCommands {
     Build {
         #[arg(add = ArgValueCompleter::new(complete_tests))]
         name: String,
+
+        /// Render real secret() values instead of masked placeholders.
+        /// Intended for local debugging only; build output is not executed.
+        #[arg(long)]
+        reveal_secrets: bool,
     },
     /// Run a particular test, or all tests if no name provided.
     Run {
@@ -256,7 +270,8 @@ impl TelemetryDescribe for TestCommands {
     fn telemetry(&self) -> TelemetryInfo {
         match self {
             TestCommands::New { .. } => TelemetryInfo::new("new"),
-            TestCommands::Build { .. } => TelemetryInfo::new("build"),
+            TestCommands::Build { reveal_secrets, .. } => TelemetryInfo::new("build")
+                .with_properties(vec![("opt_reveal_secrets", reveal_secrets.to_string())]),
             TestCommands::Run { name } => TelemetryInfo::new("run")
                 .with_properties(vec![("run_all", name.is_none().to_string())]),
             TestCommands::Compare { name } => TelemetryInfo::new("compare")
@@ -368,6 +383,7 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
                     migration,
                     pinned,
                     variables,
+                    reveal_secrets,
                 }) => {
                     let vars = match variables {
                         Some(vars_path) => Some(config.load_variables_from_path(&vars_path).await?),
@@ -377,6 +393,7 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
                         migration,
                         pinned,
                         variables: vars,
+                        reveal_secrets,
                     }
                     .execute(config)
                     .await
@@ -426,7 +443,12 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
         }
         Some(Commands::Test { command }) => match command {
             Some(TestCommands::New { name }) => NewTest { name }.execute(config).await,
-            Some(TestCommands::Build { name }) => BuildTest { name }.execute(config).await,
+            Some(TestCommands::Build { name, reveal_secrets }) => BuildTest {
+                name,
+                reveal_secrets,
+            }
+            .execute(config)
+            .await,
             Some(TestCommands::Run { name }) => RunTest { name }.execute(config).await,
             Some(TestCommands::Compare { name }) => CompareTests { name }.execute(config).await,
             Some(TestCommands::Expect { name }) => ExpectTest { name }.execute(config).await,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,8 @@ pub enum Commands {
     Test {
         #[command(subcommand)]
         command: Option<TestCommands>,
+        #[arg(short, long, global = true)]
+        environment: Option<String>,
     },
 }
 
@@ -89,7 +91,7 @@ impl TelemetryDescribe for Commands {
                 }
                 None => TelemetryInfo::new("migration"),
             },
-            Commands::Test { command } => match command {
+            Commands::Test { command, .. } => match command {
                 Some(cmd) => {
                     let mut info = cmd.telemetry();
                     info.label = format!("test {}", info.label);
@@ -371,7 +373,12 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
             command,
             environment,
         }) => {
-            config.environment = environment;
+            // Only override what was loaded from spawn.toml when --environment
+            // was actually passed; otherwise preserve an explicit top-level
+            // `environment` setting (or the target's own) instead of erasing it.
+            if let Some(environment) = environment {
+                config.environment = Some(environment);
+            }
             match command {
                 Some(MigrationCommands::New { name }) => {
                     NewMigration { name }.execute(config).await
@@ -441,22 +448,166 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
                 }
             }
         }
-        Some(Commands::Test { command }) => match command {
-            Some(TestCommands::New { name }) => NewTest { name }.execute(config).await,
-            Some(TestCommands::Build { name, reveal_secrets }) => BuildTest {
-                name,
-                reveal_secrets,
+        Some(Commands::Test {
+            command,
+            environment,
+        }) => {
+            if let Some(environment) = environment {
+                config.environment = Some(environment);
             }
-            .execute(config)
-            .await,
-            Some(TestCommands::Run { name }) => RunTest { name }.execute(config).await,
-            Some(TestCommands::Compare { name }) => CompareTests { name }.execute(config).await,
-            Some(TestCommands::Expect { name }) => ExpectTest { name }.execute(config).await,
-            None => {
-                eprintln!("No test subcommand specified");
-                Ok(Outcome::Unimplemented)
+            match command {
+                Some(TestCommands::New { name }) => NewTest { name }.execute(config).await,
+                Some(TestCommands::Build {
+                    name,
+                    reveal_secrets,
+                }) => {
+                    BuildTest {
+                        name,
+                        reveal_secrets,
+                    }
+                    .execute(config)
+                    .await
+                }
+                Some(TestCommands::Run { name }) => RunTest { name }.execute(config).await,
+                Some(TestCommands::Compare { name }) => {
+                    CompareTests { name }.execute(config).await
+                }
+                Some(TestCommands::Expect { name }) => ExpectTest { name }.execute(config).await,
+                None => {
+                    eprintln!("No test subcommand specified");
+                    Ok(Outcome::Unimplemented)
+                }
             }
-        },
+        }
         None => Ok(Outcome::Unimplemented),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConfigLoaderSaver;
+    use crate::engine::{EngineType, TargetConfig};
+    use opendal::services::Memory;
+    use std::collections::HashMap;
+
+    /// A config with a target permanently set to "dev", and an optional
+    /// explicit top-level `environment` override (`None` reflects the
+    /// common case: nothing set in spawn.toml).
+    fn test_config(top_level_environment: Option<&str>) -> Config {
+        let mut targets = HashMap::new();
+        targets.insert(
+            "dev_target".to_string(),
+            TargetConfig {
+                engine: EngineType::PostgresPSQL,
+                spawn_database: None,
+                spawn_schema: "_spawn".to_string(),
+                environment: "dev".to_string(),
+                command: None,
+            },
+        );
+        let loader = ConfigLoaderSaver {
+            environment: top_level_environment.map(|s| s.to_string()),
+            project_id: None,
+            spawn_folder: "spawn".to_string(),
+            target: Some("dev_target".to_string()),
+            targets: Some(targets),
+            secrets: None,
+            test_template: None,
+            up_template: None,
+            telemetry: Some(false),
+        };
+        let op = opendal::Operator::new(Memory::default()).unwrap();
+        loader.build(op, None)
+    }
+
+    /// Table-driven coverage of how a target's environment interacts with
+    /// spawn.toml's top-level `environment` and the `--environment` CLI
+    /// flag, for both Migration and Test commands.
+    #[tokio::test]
+    async fn resolved_environment_matrix() {
+        struct Case {
+            name: &'static str,
+            is_test_command: bool,
+            top_level_environment: Option<&'static str>,
+            cli_flag: Option<&'static str>,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "test: no config or flag falls back to the target's own environment",
+                is_test_command: true,
+                top_level_environment: None,
+                cli_flag: None,
+                expected: "dev",
+            },
+            Case {
+                name: "test: --environment flag overrides the target",
+                is_test_command: true,
+                top_level_environment: None,
+                cli_flag: Some("staging"),
+                expected: "staging",
+            },
+            Case {
+                name: "test: explicit top-level override is preserved when flag is absent",
+                is_test_command: true,
+                top_level_environment: Some("staging"),
+                cli_flag: None,
+                expected: "staging",
+            },
+            Case {
+                name: "migration: no config or flag falls back to the target's own environment",
+                is_test_command: false,
+                top_level_environment: None,
+                cli_flag: None,
+                expected: "dev",
+            },
+            Case {
+                name: "migration: --environment flag overrides the target",
+                is_test_command: false,
+                top_level_environment: None,
+                cli_flag: Some("staging"),
+                expected: "staging",
+            },
+            Case {
+                name: "migration: explicit top-level override is preserved when flag is absent",
+                is_test_command: false,
+                top_level_environment: Some("staging"),
+                cli_flag: None,
+                expected: "staging",
+            },
+        ];
+
+        for case in cases {
+            let mut config = test_config(case.top_level_environment);
+            let environment = case.cli_flag.map(String::from);
+            let command = if case.is_test_command {
+                Commands::Test {
+                    command: None,
+                    environment,
+                }
+            } else {
+                Commands::Migration {
+                    command: None,
+                    environment,
+                }
+            };
+            let cli = Cli {
+                debug: false,
+                config_file: "spawn.toml".to_string(),
+                target: None,
+                internal_telemetry: false,
+                command: Some(command),
+            };
+
+            run_command(cli, &mut config).await.unwrap();
+            assert_eq!(
+                config.target_config().unwrap().environment,
+                case.expected,
+                "case: {}",
+                case.name
+            );
+        }
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -82,6 +82,7 @@ impl Init {
             target: Some("postgres_psql".to_string()),
             environment: None,
             targets: Some(targets),
+            secrets: None,
             project_id: Some(project_id.clone()),
             telemetry: None,
         };

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -3,9 +3,27 @@ use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
 use crate::config::Config;
 use crate::engine::{Engine, MigrationError};
 use crate::migrator::Migrator;
-use crate::secrets::SecretsRenderMode;
+use crate::secrets::{SecretsRenderMode, SecretsRepository};
 use crate::variables::Variables;
 use anyhow::{anyhow, Result};
+
+/// Replaces every value this render actually resolved with a placeholder,
+/// across the error's full chain, and rebuilds a flat error from the
+/// result. `apply` executes real SQL, and a failing statement (e.g. a
+/// constraint violation) can make Postgres echo a literal value — possibly
+/// a secret — back in its own error output, entirely independent of the
+/// migration_history checksum protection. See the Secrets guide for the
+/// residual risk this doesn't close.
+fn redact_secrets(err: anyhow::Error, secrets: &SecretsRepository) -> anyhow::Error {
+    let mut text = format!("{:?}", err);
+    for value in secrets.resolved_values() {
+        if value.is_empty() {
+            continue;
+        }
+        text = text.replace(&value, "***REDACTED***");
+    }
+    anyhow!(text)
+}
 
 pub struct ApplyMigration {
     pub migration: Option<String>,
@@ -81,7 +99,7 @@ impl Command for ApplyMigration {
                             new_engine.as_ref().unwrap().as_ref()
                         }
                     };
-                    let write_fn = streaming.into_writer_fn();
+                    let (write_fn, secrets) = streaming.into_writer_fn();
                     match engine
                         .migration_apply(
                             &migration,
@@ -113,17 +131,16 @@ impl Command for ApplyMigration {
                             ));
                         }
                         Err(MigrationError::Database(e)) => {
-                            return Err(
-                                e.context(format!("Failed applying migration {}", &migration))
-                            );
+                            let err = e.context(format!("Failed applying migration {}", &migration));
+                            return Err(redact_secrets(err, &secrets));
                         }
                         Err(MigrationError::AdvisoryLock(e)) => {
-                            return Err(
-                                anyhow!("Unable to obtain advisory lock for migration").context(e)
-                            );
+                            let err =
+                                anyhow!("Unable to obtain advisory lock for migration").context(e);
+                            return Err(redact_secrets(err, &secrets));
                         }
                         Err(e @ MigrationError::NotRecorded { .. }) => {
-                            return Err(anyhow!("{}", e));
+                            return Err(redact_secrets(anyhow!("{}", e), &secrets));
                         }
                     }
                 }
@@ -142,5 +159,46 @@ impl Command for ApplyMigration {
             };
         }
         Ok(Outcome::AppliedMigrations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secrets::{SecretDefinition, SecretSource};
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn redact_secrets_strips_resolved_values_from_the_full_error_chain() {
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        // Resolve it, as a real render would while streaming to psql.
+        secrets.resolve("application_password").await.unwrap();
+
+        let simulated_psql_error = anyhow!(
+            "psql exited with code 1: ERROR: duplicate key value\nDETAIL: Key (password)=(hunter2) already exists."
+        );
+
+        let redacted = redact_secrets(simulated_psql_error, &secrets);
+
+        let full_text = format!("{:?}", redacted);
+        assert!(!full_text.contains("hunter2"));
+        assert!(full_text.contains("***REDACTED***"));
     }
 }

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -109,7 +109,15 @@ impl Command for ApplyMigration {
                     // and the component tree it was built against, before the
                     // streaming generation is consumed below.
                     let checksum = streaming.raw_checksum();
-                    let pin_hash = mgrtr.pin_hash().await?;
+                    // Prefer the pin this render actually used over a fresh
+                    // re-read of lock.toml: a second, later read here could
+                    // race a concurrent re-pin and record a hash that
+                    // doesn't match what was rendered. Only --no-pin (no
+                    // lock file involved) falls back to recomputing one.
+                    let pin_hash = match streaming.pin_hash() {
+                        Some(hash) => hash.to_string(),
+                        None => mgrtr.recompute_pin_hash().await?,
+                    };
 
                     // Use shared engine if reuse_connection is enabled, otherwise create new
                     let new_engine: Option<Box<dyn Engine>>;

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -16,7 +16,12 @@ use anyhow::{anyhow, Result};
 /// residual risk this doesn't close.
 fn redact_secrets(err: anyhow::Error, secrets: &SecretsRepository) -> anyhow::Error {
     let mut text = format!("{:?}", err);
-    for value in secrets.resolved_values() {
+    // Longest first: if a shorter secret is a substring of a longer one,
+    // redacting the shorter one first would consume part of the longer one
+    // and leave the rest of it exposed.
+    let mut values = secrets.resolved_values();
+    values.sort_by_key(|b| std::cmp::Reverse(b.len()));
+    for value in values {
         if value.is_empty() {
             continue;
         }
@@ -131,7 +136,8 @@ impl Command for ApplyMigration {
                             ));
                         }
                         Err(MigrationError::Database(e)) => {
-                            let err = e.context(format!("Failed applying migration {}", &migration));
+                            let err =
+                                e.context(format!("Failed applying migration {}", &migration));
                             return Err(redact_secrets(err, &secrets));
                         }
                         Err(MigrationError::AdvisoryLock(e)) => {
@@ -200,5 +206,55 @@ mod tests {
         let full_text = format!("{:?}", redacted);
         assert!(!full_text.contains("hunter2"));
         assert!(full_text.contains("***REDACTED***"));
+    }
+
+    #[tokio::test]
+    async fn redact_secrets_fully_redacts_a_secret_that_contains_another_as_a_substring() {
+        // This test will only fail some of the time if the sort order is ever
+        // changed to be random, but that's better than nothing.
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "short".to_string(),
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        definitions.insert(
+            "long".to_string(),
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2suffix".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        secrets.resolve("short").await.unwrap();
+        secrets.resolve("long").await.unwrap();
+
+        let simulated_psql_error = anyhow!(
+            "psql exited with code 1: ERROR: duplicate key value\nDETAIL: Key (password)=(hunter2suffix) already exists."
+        );
+
+        let redacted = redact_secrets(simulated_psql_error, &secrets);
+
+        // Regardless of which order resolved_values() happens to hand back
+        // the two secrets, the longer one must be redacted whole — not just
+        // the "hunter2" prefix it shares with the shorter secret.
+        let full_text = format!("{:?}", redacted);
+        assert!(!full_text.contains("hunter2"), "got: {}", full_text);
+        assert!(!full_text.contains("suffix"), "got: {}", full_text);
+        assert!(full_text.contains("***REDACTED***"), "got: {}", full_text);
     }
 }

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -64,6 +64,14 @@ impl Command for ApplyMigration {
                 .await
             {
                 Ok(streaming) => {
+                    // Fingerprint the raw template source (never the rendered
+                    // output, which may contain resolved secret values that
+                    // could be guessed due to us using a fast hashing method)
+                    // and the component tree it was built against, before the
+                    // streaming generation is consumed below.
+                    let checksum = streaming.raw_checksum();
+                    let pin_hash = mgrtr.pin_hash().await?;
+
                     // Use shared engine if reuse_connection is enabled, otherwise create new
                     let new_engine: Option<Box<dyn Engine>>;
                     let engine: &dyn Engine = match &shared_engine {
@@ -78,7 +86,8 @@ impl Command for ApplyMigration {
                         .migration_apply(
                             &migration,
                             write_fn,
-                            None,
+                            checksum,
+                            Some(pin_hash),
                             super::DEFAULT_NAMESPACE,
                             self.retry,
                         )

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -3,6 +3,7 @@ use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
 use crate::config::Config;
 use crate::engine::{Engine, MigrationError};
 use crate::migrator::Migrator;
+use crate::secrets::SecretsRenderMode;
 use crate::variables::Variables;
 use anyhow::{anyhow, Result};
 
@@ -57,7 +58,11 @@ impl Command for ApplyMigration {
                 String::new()
             };
             let mgrtr = Migrator::new(config, &migration, self.pinned);
-            match mgrtr.generate_streaming(self.variables.clone()).await {
+            // Apply actually executes against the database, so secrets must always be revealed.
+            match mgrtr
+                .generate_streaming(self.variables.clone(), SecretsRenderMode::Revealed)
+                .await
+            {
                 Ok(streaming) => {
                     // Use shared engine if reuse_connection is enabled, otherwise create new
                     let new_engine: Option<Box<dyn Engine>>;

--- a/src/commands/migration/apply.rs
+++ b/src/commands/migration/apply.rs
@@ -4,6 +4,7 @@ use crate::config::Config;
 use crate::engine::{Engine, MigrationError};
 use crate::migrator::Migrator;
 use crate::secrets::{SecretsRenderMode, SecretsRepository};
+use crate::sql_formatter::{self, SqlDialect};
 use crate::variables::Variables;
 use anyhow::{anyhow, Result};
 
@@ -14,13 +15,27 @@ use anyhow::{anyhow, Result};
 /// a secret — back in its own error output, entirely independent of the
 /// migration_history checksum protection. See the Secrets guide for the
 /// residual risk this doesn't close.
-fn redact_secrets(err: anyhow::Error, secrets: &SecretsRepository) -> anyhow::Error {
+///
+/// Redacts both the raw resolved value and its SQL-escaped form (via the
+/// engine's own dialect-specific escaper, so this stays correct as more
+/// engines are added). Some errors echo back a parsed value (matching the
+/// raw form), but others — e.g. a "LINE 1: ..." context on a syntax error —
+/// echo the submitted SQL text verbatim, which shows the escaped literal
+/// (quotes doubled, wrapped in quotes) rather than the raw string. A secret
+/// containing a quote or other special character would otherwise leak
+/// through that path untouched.
+fn redact_secrets(err: anyhow::Error, secrets: &SecretsRepository, dialect: SqlDialect) -> anyhow::Error {
     let mut text = format!("{:?}", err);
-    // Longest first: if a shorter secret is a substring of a longer one,
-    // redacting the shorter one first would consume part of the longer one
-    // and leave the rest of it exposed.
     let mut values = secrets.resolved_values();
-    values.sort_by_key(|b| std::cmp::Reverse(b.len()));
+    let escaped: Vec<String> = values
+        .iter()
+        .map(|value| sql_formatter::escape_string(dialect, value))
+        .collect();
+    values.extend(escaped);
+    // Longest first: if a shorter value (raw or escaped) is a substring of a
+    // longer one, redacting the shorter one first would consume part of the
+    // longer one and leave the rest of it exposed.
+    values.sort_by_key(|v| std::cmp::Reverse(v.len()));
     for value in values {
         if value.is_empty() {
             continue;
@@ -61,6 +76,7 @@ impl Command for ApplyMigration {
         };
 
         let total = migrations.len();
+        let dialect = crate::template::engine_to_dialect(&config.target_config()?.engine);
 
         // Optionally reuse the same engine (database connection) across all migrations
         let shared_engine = if self.reuse_connection {
@@ -138,15 +154,15 @@ impl Command for ApplyMigration {
                         Err(MigrationError::Database(e)) => {
                             let err =
                                 e.context(format!("Failed applying migration {}", &migration));
-                            return Err(redact_secrets(err, &secrets));
+                            return Err(redact_secrets(err, &secrets, dialect));
                         }
                         Err(MigrationError::AdvisoryLock(e)) => {
                             let err =
                                 anyhow!("Unable to obtain advisory lock for migration").context(e);
-                            return Err(redact_secrets(err, &secrets));
+                            return Err(redact_secrets(err, &secrets, dialect));
                         }
                         Err(e @ MigrationError::NotRecorded { .. }) => {
-                            return Err(redact_secrets(anyhow!("{}", e), &secrets));
+                            return Err(redact_secrets(anyhow!("{}", e), &secrets, dialect));
                         }
                     }
                 }
@@ -201,7 +217,7 @@ mod tests {
             "psql exited with code 1: ERROR: duplicate key value\nDETAIL: Key (password)=(hunter2) already exists."
         );
 
-        let redacted = redact_secrets(simulated_psql_error, &secrets);
+        let redacted = redact_secrets(simulated_psql_error, &secrets, SqlDialect::Postgres);
 
         let full_text = format!("{:?}", redacted);
         assert!(!full_text.contains("hunter2"));
@@ -247,7 +263,7 @@ mod tests {
             "psql exited with code 1: ERROR: duplicate key value\nDETAIL: Key (password)=(hunter2suffix) already exists."
         );
 
-        let redacted = redact_secrets(simulated_psql_error, &secrets);
+        let redacted = redact_secrets(simulated_psql_error, &secrets, SqlDialect::Postgres);
 
         // Regardless of which order resolved_values() happens to hand back
         // the two secrets, the longer one must be redacted whole — not just
@@ -255,6 +271,49 @@ mod tests {
         let full_text = format!("{:?}", redacted);
         assert!(!full_text.contains("hunter2"), "got: {}", full_text);
         assert!(!full_text.contains("suffix"), "got: {}", full_text);
+        assert!(full_text.contains("***REDACTED***"), "got: {}", full_text);
+    }
+
+    #[tokio::test]
+    async fn redact_secrets_also_strips_the_escaped_form_of_a_secret() {
+        // A secret containing a quote renders into the SQL sent to psql as
+        // an escaped literal (quotes doubled, wrapped in quotes). Some
+        // Postgres errors echo back the submitted SQL text verbatim (e.g. a
+        // "LINE 1: ..." context on a syntax error) rather than the parsed
+        // value, so that escaped form — not just the raw value — must be
+        // redacted too.
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter'2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        secrets.resolve("application_password").await.unwrap();
+
+        // Simulates a "LINE 1: ..." context echoing the submitted SQL text,
+        // which shows the escaped literal 'hunter''2' rather than the raw
+        // value hunter'2.
+        let simulated_psql_error = anyhow!(
+            "psql exited with code 1: ERROR: syntax error at or near \"FRIM\"\n\
+             LINE 1: SELECT * FRIM foo WHERE password = 'hunter''2';"
+        );
+
+        let redacted = redact_secrets(simulated_psql_error, &secrets, SqlDialect::Postgres);
+
+        let full_text = format!("{:?}", redacted);
+        assert!(!full_text.contains("hunter"), "got: {}", full_text);
         assert!(full_text.contains("***REDACTED***"), "got: {}", full_text);
     }
 }

--- a/src/commands/migration/build.rs
+++ b/src/commands/migration/build.rs
@@ -1,6 +1,7 @@
 use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
 use crate::config::Config;
 use crate::migrator::Migrator;
+use crate::secrets::SecretsRenderMode;
 use crate::store::get_migration_fs_status;
 use crate::variables::Variables;
 use anyhow::Result;
@@ -9,6 +10,10 @@ pub struct BuildMigration {
     pub migration: String,
     pub pinned: bool,
     pub variables: Option<Variables>,
+    /// Render real secret values instead of masked placeholders. Only
+    /// intended for local debugging: the output of `build` is meant for
+    /// inspection, not execution.
+    pub reveal_secrets: bool,
 }
 
 impl TelemetryDescribe for BuildMigration {
@@ -16,6 +21,7 @@ impl TelemetryDescribe for BuildMigration {
         TelemetryInfo::new("migration build").with_properties(vec![
             ("opt_pinned", self.pinned.to_string()),
             ("has_variables", self.variables.is_some().to_string()),
+            ("opt_reveal_secrets", self.reveal_secrets.to_string()),
         ])
     }
 }
@@ -34,7 +40,16 @@ impl Command for BuildMigration {
             false
         };
 
-        match mgrtr.generate_streaming(self.variables.clone()).await {
+        let secrets_mode = if self.reveal_secrets {
+            SecretsRenderMode::Revealed
+        } else {
+            SecretsRenderMode::Masked
+        };
+
+        match mgrtr
+            .generate_streaming(self.variables.clone(), secrets_mode)
+            .await
+        {
             Ok(gen) => {
                 let mut buffer = Vec::new();
                 gen.render_to_writer(&mut buffer)

--- a/src/commands/test/build.rs
+++ b/src/commands/test/build.rs
@@ -1,22 +1,33 @@
 use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
 use crate::config::Config;
+use crate::secrets::SecretsRenderMode;
 use crate::sqltest::Tester;
 use anyhow::Result;
 
 pub struct BuildTest {
     pub name: String,
+    /// Render real secret values instead of masked placeholders.
+    pub reveal_secrets: bool,
 }
 
 impl TelemetryDescribe for BuildTest {
     fn telemetry(&self) -> TelemetryInfo {
-        TelemetryInfo::new("test build")
+        TelemetryInfo::new("test build").with_properties(vec![(
+            "opt_reveal_secrets",
+            self.reveal_secrets.to_string(),
+        )])
     }
 }
 
 impl Command for BuildTest {
     async fn execute(&self, config: &Config) -> Result<Outcome> {
         let tester = Tester::new(config, &self.name);
-        let result = tester.generate(None).await?;
+        let secrets_mode = if self.reveal_secrets {
+            SecretsRenderMode::Revealed
+        } else {
+            SecretsRenderMode::Masked
+        };
+        let result = tester.generate(None, secrets_mode).await?;
         println!("{}", result);
         Ok(Outcome::Success)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,8 +92,6 @@ impl ConfigLoaderSaver {
             // Eg.. `APP_DEBUG=1 ./target/app` would set the `debug` key
             .add_source(config::Environment::with_prefix("SPAWN"))
             .set_override_option("target", target)?
-            .set_default("environment", "prod")
-            .context("could not set default environment")?
             .build()?
             .try_deserialize()?;
 
@@ -279,5 +277,37 @@ impl Config {
         let extension = path.split('.').last().unwrap_or("");
         Variables::from_str(extension, &content_str)
             .context(format!("Failed to parse variables file '{}'", path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::services::Memory;
+
+    #[tokio::test]
+    async fn load_without_top_level_environment_does_not_manufacture_one() {
+        let op = Operator::new(Memory::default()).unwrap();
+        op.write(
+            "spawn.toml",
+            r#"
+spawn_folder = "spawn"
+target = "dev_target"
+
+[targets.dev_target]
+engine = "postgres-psql"
+environment = "dev"
+"#,
+        )
+        .await
+        .unwrap();
+
+        let config = Config::load("spawn.toml", &op, None).await.unwrap();
+
+        // No top-level `environment` was set in spawn.toml, so this must stay
+        // None rather than defaulting to "prod" — target_config() only
+        // overrides the target's own environment when this is explicitly Some.
+        assert_eq!(config.environment, None);
+        assert_eq!(config.target_config().unwrap().environment, "dev");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::engine::{postgres_psql::PSQL, Engine, EngineType, TargetConfig};
 use crate::pinfile::LockData;
+use crate::secrets::SecretDefinition;
 use crate::variables::Variables;
 use anyhow::{anyhow, Context, Result};
 use opendal::Operator;
@@ -21,6 +22,8 @@ pub struct ConfigLoaderSaver {
     pub spawn_folder: String,
     pub target: Option<String>,
     pub targets: Option<HashMap<String, TargetConfig>>,
+    /// Named secrets available to templates via the `secret()` function.
+    pub secrets: Option<HashMap<String, SecretDefinition>>,
     /// Allows you to override the default template for test new with a
     /// custom one.
     pub test_template: Option<String>,
@@ -45,6 +48,7 @@ impl ConfigLoaderSaver {
             spawn_folder: self.spawn_folder,
             target: self.target,
             targets: self.targets.unwrap_or_default(),
+            secrets: self.secrets.unwrap_or_default(),
             test_template: self.test_template,
             up_template: self.up_template,
             telemetry: self.telemetry.unwrap_or(true),
@@ -189,6 +193,8 @@ pub struct Config {
     spawn_folder: String,
     pub target: Option<String>,
     pub targets: HashMap<String, TargetConfig>,
+    /// Named secrets available to templates via the `secret()` function.
+    pub secrets: HashMap<String, SecretDefinition>,
     /// Allows you to override the default template for test new with a
     /// custom one.
     pub test_template: Option<String>,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -266,40 +266,50 @@ pub async fn resolve_command_spec(spec: CommandSpec) -> Result<Vec<String>> {
     }
 }
 
-/// Executes a provider command and parses its output as a shell command.
+/// Executes a command and returns its trimmed stdout.
 ///
-/// The provider must output a shell command string (e.g., `ssh -t -i /path/key user@host`).
-/// The parser handles quoted strings properly using POSIX shell-style parsing.
-async fn resolve_provider(provider: &[String]) -> Result<Vec<String>> {
-    if provider.is_empty() {
-        return Err(anyhow!("Provider command cannot be empty"));
+/// Shared by anything that resolves a value by running an external command
+/// (provider commands, command-sourced secrets).
+pub(crate) async fn run_capture_stdout(command: &[String]) -> Result<String> {
+    if command.is_empty() {
+        return Err(anyhow!("command cannot be empty"));
     }
 
-    let output = Command::new(&provider[0])
-        .args(&provider[1..])
+    let output = Command::new(&command[0])
+        .args(&command[1..])
         .output()
         .await
-        .context("Failed to execute provider command")?;
+        .context("Failed to execute command")?;
 
     if !output.status.success() {
         return Err(anyhow!(
-            "Provider command failed (exit {}): {}",
+            "command failed (exit {}): {}",
             output.status.code().unwrap_or(-1),
             String::from_utf8_lossy(&output.stderr)
         ));
     }
 
-    let stdout = String::from_utf8(output.stdout).context("Provider output is not valid UTF-8")?;
+    let stdout = String::from_utf8(output.stdout).context("command output is not valid UTF-8")?;
     let trimmed = stdout.trim();
 
     if trimmed.is_empty() {
-        return Err(anyhow!("Provider returned empty output"));
+        return Err(anyhow!("command returned empty output"));
     }
+
+    Ok(trimmed.to_string())
+}
+
+/// Executes a provider command and parses its output as a shell command.
+///
+/// The provider must output a shell command string (e.g., `ssh -t -i /path/key user@host`).
+/// The parser handles quoted strings properly using POSIX shell-style parsing.
+async fn resolve_provider(provider: &[String]) -> Result<Vec<String>> {
+    let trimmed = run_capture_stdout(provider).await?;
 
     // Parses a shell command string into a Vec<String>, handling quoted arguments.
     //
     // Uses the `shlex` crate for proper POSIX shell-style parsing.
-    shlex::split(trimmed).ok_or_else(|| anyhow!("Failed to parse shell command: {}", trimmed))
+    shlex::split(&trimmed).ok_or_else(|| anyhow!("Failed to parse shell command: {}", trimmed))
 }
 
 /// Type alias for the writer closure used in execute_with_writer

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -286,7 +286,10 @@ pub(crate) async fn run_capture_stdout(command: &[String]) -> Result<String> {
 
     if !output.status.success() {
         let exit_code = output.status.code().unwrap_or(-1);
-        if std::env::var("SPAWN_DEBUG_COMMAND_STDERR").is_ok() {
+        if matches!(
+            std::env::var("SPAWN_DEBUG_COMMAND_STDERR").as_deref(),
+            Ok("1")
+        ) {
             return Err(anyhow!(
                 "command failed (exit {}): {}",
                 exit_code,

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -268,8 +268,11 @@ pub async fn resolve_command_spec(spec: CommandSpec) -> Result<Vec<String>> {
 
 /// Executes a command and returns its trimmed stdout.
 ///
-/// Shared by anything that resolves a value by running an external command
-/// (provider commands, command-sourced secrets).
+/// Shared by provider commands and command-sourced secrets, so a failing
+/// command's stderr is withheld by default — a secret source that fails
+/// never gets its value cached for later redaction, so a provider script
+/// echoing its input on failure would otherwise leak unredactably. Set
+/// `SPAWN_DEBUG_COMMAND_STDERR=1` to see it for local debugging.
 pub(crate) async fn run_capture_stdout(command: &[String]) -> Result<String> {
     if command.is_empty() {
         return Err(anyhow!("command cannot be empty"));
@@ -282,10 +285,19 @@ pub(crate) async fn run_capture_stdout(command: &[String]) -> Result<String> {
         .context("Failed to execute command")?;
 
     if !output.status.success() {
+        let exit_code = output.status.code().unwrap_or(-1);
+        if std::env::var("SPAWN_DEBUG_COMMAND_STDERR").is_ok() {
+            return Err(anyhow!(
+                "command failed (exit {}): {}",
+                exit_code,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
         return Err(anyhow!(
-            "command failed (exit {}): {}",
-            output.status.code().unwrap_or(-1),
-            String::from_utf8_lossy(&output.stderr)
+            "command failed (exit {}). Its output is not shown, since this command may be \
+             resolving a secret whose value would then be unredactable. Set \
+             SPAWN_DEBUG_COMMAND_STDERR=1 to see it for local debugging.",
+            exit_code
         ));
     }
 
@@ -368,4 +380,45 @@ pub trait Engine: Send + Sync {
         &self,
         namespace: Option<&str>,
     ) -> MigrationResult<Vec<MigrationDbInfo>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Both scenarios live in one test (rather than two) since they share a
+    // process-global env var: running them as separate tests would race
+    // against Rust's default parallel test execution.
+    #[tokio::test]
+    async fn run_capture_stdout_only_includes_stderr_when_opted_in() {
+        std::env::remove_var("SPAWN_DEBUG_COMMAND_STDERR");
+        let command = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "echo secret-provider-detail >&2; exit 1".to_string(),
+        ];
+
+        let err = run_capture_stdout(&command).await.unwrap_err();
+        let message = err.to_string();
+        assert!(
+            !message.contains("secret-provider-detail"),
+            "stderr should be suppressed by default, got: {}",
+            message
+        );
+        assert!(
+            message.contains("exit 1"),
+            "exit code should still be shown, got: {}",
+            message
+        );
+
+        std::env::set_var("SPAWN_DEBUG_COMMAND_STDERR", "1");
+        let err = run_capture_stdout(&command).await.unwrap_err();
+        let message = err.to_string();
+        std::env::remove_var("SPAWN_DEBUG_COMMAND_STDERR");
+        assert!(
+            message.contains("secret-provider-detail"),
+            "stderr should be included when opted in, got: {}",
+            message
+        );
+    }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -335,10 +335,17 @@ pub trait Engine: Send + Sync {
         merge_stderr: bool,
     ) -> Result<(), EngineError>;
 
+    /// Applies a migration and records the outcome.
+    /// - `checksum`: A fingerprint for the migration_history audit trail.
+    ///   Callers should hash the migration's raw (unrendered) template
+    ///   source, not the rendered/executed SQL — the rendered output may
+    ///   contain resolved secret values, which must never be persisted or
+    ///   derivable from what's persisted.
     async fn migration_apply(
         &self,
         migration_name: &str,
         write_fn: WriterFn,
+        checksum: String,
         pin_hash: Option<String>,
         namespace: &str,
         retry: bool,

--- a/src/engine/postgres_psql.rs
+++ b/src/engine/postgres_psql.rs
@@ -268,10 +268,13 @@ impl Engine for PSQL {
             Ok(())
         });
 
-        // 6. Wait for writing to complete
-        writer_handle
+        // 6. Wait for writing to complete. Captured rather than propagated
+        // immediately — psql may still be running and must be reaped (step 8)
+        // before we return, even on a writer failure.
+        let writer_result = writer_handle
             .await
-            .map_err(|e| EngineError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))??;
+            .map_err(|e| EngineError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))
+            .and_then(|r| r.map_err(EngineError::Io));
 
         // 7. Wait for stdout copy if applicable (must complete before we read the buffer)
         if let Some(handle) = stdout_handle {
@@ -284,6 +287,10 @@ impl Engine for PSQL {
             Some(handle) => handle.await.unwrap_or_default(),
             None => Vec::new(),
         };
+
+        // Takes precedence over psql's own status: an aborted render can
+        // leave psql exiting 0 (e.g. a quiet rollback on early EOF).
+        writer_result?;
 
         if !status.success() {
             return Err(EngineError::ExecutionFailed {
@@ -898,10 +905,12 @@ impl PSQL {
                 )
             }
             Err(EngineError::Io(e)) => {
-                return Err(MigrationError::Database(anyhow!(
-                    "IO error running migration: {}",
-                    e
-                )));
+                // Writer failed (e.g. an unresolved secret), not psql itself.
+                // Still record a Failure row — SQL may already have run.
+                (
+                    MigrationStatus::Failure,
+                    Some(format!("failed while streaming migration SQL: {}", e)),
+                )
             }
         };
 

--- a/src/engine/postgres_psql.rs
+++ b/src/engine/postgres_psql.rs
@@ -9,6 +9,7 @@ use crate::engine::{
     TargetConfig, WriterFn,
 };
 use crate::escape::{EscapedIdentifier, EscapedLiteral, EscapedQuery, InsecureRawSql};
+use crate::secrets::SecretsRenderMode;
 use crate::sql_query;
 use crate::store::pinner::latest::Latest;
 use crate::store::{operator_from_includedir, Store};
@@ -578,7 +579,9 @@ impl PSQL {
                 "json",
                 &serde_json::json!({"schema": &self.target_config.spawn_schema}).to_string(),
             )?;
-            let gen = migrator.generate_streaming(Some(variables)).await?;
+            let gen = migrator
+                .generate_streaming(Some(variables), SecretsRenderMode::Revealed)
+                .await?;
             let mut buffer = Vec::new();
             gen.render_to_writer(&mut buffer)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;

--- a/src/engine/postgres_psql.rs
+++ b/src/engine/postgres_psql.rs
@@ -24,7 +24,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
-use twox_hash::xxhash3_128;
 use twox_hash::XxHash64;
 
 /// Returns the advisory lock key used to prevent concurrent migrations.
@@ -300,6 +299,7 @@ impl Engine for PSQL {
         &self,
         migration_name: &str,
         write_fn: WriterFn,
+        checksum: String,
         pin_hash: Option<String>,
         namespace: &str,
         retry: bool,
@@ -307,6 +307,7 @@ impl Engine for PSQL {
         self.apply_and_record_migration_v1(
             migration_name,
             write_fn,
+            checksum,
             pin_hash,
             EscapedLiteral::new(namespace),
             retry,
@@ -481,37 +482,6 @@ impl tokio::io::AsyncWrite for SharedBufWriter {
     }
 }
 
-/// A writer that tees output to both an inner writer and a hasher for checksum calculation.
-/// This allows streaming the migration SQL while computing the checksum on-the-fly.
-struct TeeWriter<W: Write> {
-    inner: W,
-    hasher: xxhash3_128::Hasher,
-}
-
-impl<W: Write> TeeWriter<W> {
-    fn new(inner: W) -> Self {
-        Self {
-            inner,
-            hasher: xxhash3_128::Hasher::new(),
-        }
-    }
-
-    fn finish(self) -> (W, u128) {
-        (self.inner, self.hasher.finish_128())
-    }
-}
-
-impl<W: Write> Write for TeeWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.hasher.write(buf);
-        self.inner.write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.flush()
-    }
-}
-
 impl PSQL {
     pub async fn update_schema(&self) -> Result<()> {
         // Create a memory operator from the included directory containing
@@ -582,6 +552,7 @@ impl PSQL {
             let gen = migrator
                 .generate_streaming(Some(variables), SecretsRenderMode::Revealed)
                 .await?;
+            let checksum = gen.raw_checksum();
             let mut buffer = Vec::new();
             gen.render_to_writer(&mut buffer)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
@@ -601,6 +572,7 @@ impl PSQL {
                 .apply_and_record_migration_v1(
                     migration_name,
                     write_fn,
+                    checksum,
                     None, // pin_hash not used for engine migrations
                     self.safe_spawn_namespace(),
                     false, // no retry for internal schema migrations
@@ -835,6 +807,7 @@ impl PSQL {
         &self,
         migration_name: &str,
         write_fn: WriterFn,
+        checksum: String,
         pin_hash: Option<String>,
         namespace: EscapedLiteral,
         retry: bool,
@@ -880,10 +853,6 @@ impl PSQL {
         let start_time = Instant::now();
         let lock_checksum = migration_lock_key();
 
-        // Use Arc<Mutex<>> to extract checksum from the closure
-        let checksum_result: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        let checksum_result_clone = checksum_result.clone();
-
         // Session 1: Run the migration SQL only
         let migration_result = self
             .execute_with_writer(
@@ -897,16 +866,12 @@ impl PSQL {
                         .as_bytes(),
                     )?;
 
-                    // Wrap the writer in a TeeWriter to compute checksum while streaming
-                    let mut tee_writer = TeeWriter::new(writer);
-
-                    // Execute the user's write function (streams migration SQL)
-                    write_fn(&mut tee_writer)?;
-
-                    // Extract the checksum
-                    let (_writer, content_checksum) = tee_writer.finish();
-                    let checksum_hex = format!("{:032x}", content_checksum);
-                    *checksum_result_clone.lock().unwrap() = Some(checksum_hex);
+                    // Stream the migration SQL straight through — no buffering,
+                    // no tee'd hashing. The checksum is a hash of the migration's
+                    // raw template source (see StreamingGeneration::raw_checksum),
+                    // computed by the caller before this closure ever runs, so it
+                    // can never contain a resolved secret value.
+                    write_fn(writer)?;
 
                     Ok(())
                 }),
@@ -916,7 +881,6 @@ impl PSQL {
             .await;
 
         let duration = start_time.elapsed().as_secs_f32();
-        let checksum_hex = checksum_result.lock().unwrap().clone();
 
         // Determine status based on session 1 result
         let (status, migration_error) = match &migration_result {
@@ -948,7 +912,7 @@ impl PSQL {
                 &namespace,
                 status,
                 MigrationActivity::Apply,
-                checksum_hex.as_deref(),
+                Some(checksum.as_str()),
                 Some(duration),
                 pin_hash.as_deref(),
                 None,

--- a/src/engine/postgres_psql.rs
+++ b/src/engine/postgres_psql.rs
@@ -106,10 +106,13 @@ impl PSQL {
         let safe_status = EscapedLiteral::new(status.as_str());
         let safe_activity = EscapedLiteral::new(activity.as_str());
         let safe_description = EscapedLiteral::new(description.unwrap_or(""));
-        // If no checksum provided, use empty bytea (decode returns empty bytea for empty string)
-        let checksum_expr = checksum
-            .map(|c| format!("decode('{}', 'hex')", c))
-            .unwrap_or_else(|| "decode('', 'hex')".to_string());
+        // If no checksum provided, use empty bytea (decode returns empty bytea for empty string).
+        // checksum is caller-supplied, so it's escaped via EscapedLiteral rather than
+        // interpolated directly — decode() itself rejects anything that isn't valid hex.
+        let checksum_expr = format!(
+            "decode({}, 'hex')",
+            EscapedLiteral::new(checksum.unwrap_or(""))
+        );
         let checksum_raw = InsecureRawSql::new(&checksum_expr);
         let safe_pin_hash = pin_hash.map(|h| EscapedLiteral::new(h));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod engine;
 pub mod escape;
 pub mod migrator;
 pub mod pinfile;
+pub mod secrets;
 pub mod sql_formatter;
 pub mod sqltest;
 pub mod store;

--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -50,6 +50,7 @@ impl Migrator {
     pub async fn generate_streaming(
         &self,
         variables: Option<crate::variables::Variables>,
+        secrets_mode: crate::secrets::SecretsRenderMode,
     ) -> Result<template::StreamingGeneration> {
         let lock_file = if self.use_pinned {
             let path = self.config.pather().migration_lock_file_path(&self.name);
@@ -58,6 +59,7 @@ impl Migrator {
             None
         };
         let script_path = &self.config.pather().migration_script_file_path(&self.name);
-        template::generate_streaming(&self.config, lock_file, script_path, variables).await
+        template::generate_streaming(&self.config, lock_file, script_path, variables, secrets_mode)
+            .await
     }
 }

--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -62,4 +62,24 @@ impl Migrator {
         template::generate_streaming(&self.config, lock_file, script_path, variables, secrets_mode)
             .await
     }
+
+    /// The pin hash to record for this migration: the real hash from
+    /// `lock.toml` when using pinned components, or an equivalent hash
+    /// computed against the current (unpinned) component tree otherwise —
+    /// `snapshot`'s `store_path: None` computes the same root hash a real
+    /// pin would without writing anything to the persistent `pinned/` store.
+    pub async fn pin_hash(&self) -> Result<String> {
+        if self.use_pinned {
+            let lock_path = self.config.pather().migration_lock_file_path(&self.name);
+            let lock = self.config.load_lock_file(&lock_path).await?;
+            Ok(lock.pin)
+        } else {
+            crate::store::pinner::snapshot(
+                self.config.operator(),
+                None,
+                &self.config.pather().components_folder(),
+            )
+            .await
+        }
+    }
 }

--- a/src/migrator.rs
+++ b/src/migrator.rs
@@ -63,23 +63,20 @@ impl Migrator {
             .await
     }
 
-    /// The pin hash to record for this migration: the real hash from
-    /// `lock.toml` when using pinned components, or an equivalent hash
-    /// computed against the current (unpinned) component tree otherwise —
+    /// The pin hash `--no-pin` should record: freshly recomputed from the
+    /// current, live component tree on every call, never read from
+    /// `lock.toml`. A pinned migration's pin hash instead comes from
+    /// `StreamingGeneration::pin_hash()`, captured from the same lock read
+    /// used to render, so it can never drift from what was actually
+    /// rendered — the way a second, independent read here once could.
     /// `snapshot`'s `store_path: None` computes the same root hash a real
-    /// pin would without writing anything to the persistent `pinned/` store.
-    pub async fn pin_hash(&self) -> Result<String> {
-        if self.use_pinned {
-            let lock_path = self.config.pather().migration_lock_file_path(&self.name);
-            let lock = self.config.load_lock_file(&lock_path).await?;
-            Ok(lock.pin)
-        } else {
-            crate::store::pinner::snapshot(
-                self.config.operator(),
-                None,
-                &self.config.pather().components_folder(),
-            )
-            .await
-        }
+    /// pin would, without writing anything to the persistent `pinned/` store.
+    pub async fn recompute_pin_hash(&self) -> Result<String> {
+        crate::store::pinner::snapshot(
+            self.config.operator(),
+            None,
+            &self.config.pather().components_folder(),
+        )
+        .await
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -197,6 +197,17 @@ impl SecretsRepository {
             SecretsRenderMode::Revealed => value,
         })
     }
+
+    /// Every secret value actually resolved so far during this render.
+    /// Used to redact captured process output (e.g. psql stderr) that may
+    /// otherwise echo a secret back verbatim — see the Secrets guide's note
+    /// on why this is a render-mode-independent, best-effort measure.
+    pub fn resolved_values(&self) -> Vec<String> {
+        self.secrets
+            .values()
+            .filter_map(|secret| secret.resolved.lock().unwrap().clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -10,8 +10,15 @@ use std::sync::Mutex;
 pub enum SecretSource {
     /// Read from an OS environment variable.
     Env { name: String },
-    /// Read the contents of a file (trailing newline stripped).
+    /// Read a file via spawn's configured operator (trailing newline
+    /// stripped), resolved the same way any other file spawn reads is. Not
+    /// a real filesystem path — use `host_file` for that.
     File { path: String },
+    /// Read a file directly from the host filesystem (trailing newline
+    /// stripped), bypassing the operator. For secrets mounted on the host
+    /// outside spawn's storage, e.g. Docker/Kubernetes secrets under
+    /// `/run/secrets`, systemd's `LoadCredential=`, etc.
+    HostFile { path: String },
     /// Run a command and use its trimmed stdout as the value.
     Command { command: Vec<String> },
     /// An inline value. Requires `insecure = true`, so a plaintext secret
@@ -40,6 +47,14 @@ impl SecretSource {
                     .to_bytes();
                 let text =
                     String::from_utf8(bytes.to_vec()).context("secret file is not valid UTF-8")?;
+                Ok(text.trim_end_matches(['\n', '\r']).to_string())
+            }
+            SecretSource::HostFile { path } => {
+                let bytes = tokio::fs::read(path)
+                    .await
+                    .with_context(|| format!("could not read secret host file '{}'", path))?;
+                let text = String::from_utf8(bytes)
+                    .context("secret host file is not valid UTF-8")?;
                 Ok(text.trim_end_matches(['\n', '\r']).to_string())
             }
             SecretSource::Command { command } => crate::engine::run_capture_stdout(command).await,
@@ -422,4 +437,63 @@ mod tests {
         assert_eq!(first, second);
     }
 
+    #[tokio::test]
+    async fn host_file_source_reads_absolute_path_regardless_of_operator_root() {
+        // Operator rooted somewhere unrelated, to prove host_file bypasses it.
+        let secret_dir = tempfile::tempdir().unwrap();
+        let secret_path = secret_dir.path().join("application-password");
+        std::fs::write(&secret_path, "host-secret\n").unwrap();
+
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::HostFile {
+                    path: secret_path.to_str().unwrap().to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Revealed);
+        let value = repository.resolve("application_password").await.unwrap();
+        assert_eq!(value, "host-secret");
+    }
+
+    #[tokio::test]
+    async fn file_source_cannot_reach_an_absolute_host_path() {
+        // opendal resolves paths relative to the operator's root even when
+        // they look absolute, so this must fail rather than silently
+        // resolve somewhere under the root.
+        let unrelated_root = tempfile::tempdir().unwrap();
+        let op = Operator::new(
+            opendal::services::Fs::default().root(unrelated_root.path().to_str().unwrap()),
+        )
+        .unwrap();
+
+        let secret_dir = tempfile::tempdir().unwrap();
+        let secret_path = secret_dir.path().join("application-password");
+        std::fs::write(&secret_path, "host-secret").unwrap();
+
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::File {
+                    path: secret_path.to_str().unwrap().to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        let err = repository
+            .resolve("application_password")
+            .await
+            .unwrap_err();
+        // .to_string() only prints the outer context; the underlying "could
+        // not read secret file" is deeper in the anyhow chain.
+        assert!(format!("{:?}", err).contains("could not read secret file"));
+    }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -97,10 +97,10 @@ impl SecretDefinition {
 /// even though they mask the result. It's decided once per render, not per
 /// secret: Spawn renders a whole template in a single streaming pass to a
 /// single destination, so there's no case where part of one render should be
-/// masked and another part not. Commands that execute the rendered SQL for
-/// real (`migration apply`, `test run`) always reveal; commands that only
-/// display it for inspection (`migration build`, `test build`) mask by
-/// default.
+    /// masked and another part not. Migration applies reveal secrets because
+    /// they execute the rendered SQL for real. Build commands mask by default,
+    /// while `test run`/`compare`/`expect` always mask secrets to prevent them
+    /// from being printed or persisted in expected output.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SecretsRenderMode {
     Masked,

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,425 @@
+use anyhow::{anyhow, Context, Result};
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Where a secret's value is actually read from.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum SecretSource {
+    /// Read from an OS environment variable.
+    Env { name: String },
+    /// Read the contents of a file (trailing newline stripped).
+    File { path: String },
+    /// Run a command and use its trimmed stdout as the value.
+    Command { command: Vec<String> },
+    /// An inline value. Requires `insecure = true`, so a plaintext secret
+    /// can't quietly end up as a "secure" default or environment override.
+    Literal {
+        value: String,
+        #[serde(default)]
+        insecure: bool,
+    },
+}
+
+impl SecretSource {
+    /// Fetches the value this source points to. Called even when the render
+    /// will mask the result, so that `build`/`test build` still verify a
+    /// secret is reachable (and that a `literal` source is marked
+    /// `insecure`) without ever displaying the real value.
+    async fn resolve(&self, operator: &Operator) -> Result<String> {
+        match self {
+            SecretSource::Env { name } => std::env::var(name)
+                .with_context(|| format!("environment variable '{}' is not set", name)),
+            SecretSource::File { path } => {
+                let bytes = operator
+                    .read(path)
+                    .await
+                    .with_context(|| format!("could not read secret file '{}'", path))?
+                    .to_bytes();
+                let text =
+                    String::from_utf8(bytes.to_vec()).context("secret file is not valid UTF-8")?;
+                Ok(text.trim_end_matches(['\n', '\r']).to_string())
+            }
+            SecretSource::Command { command } => crate::engine::run_capture_stdout(command).await,
+            SecretSource::Literal { value, insecure } => {
+                if !insecure {
+                    return Err(anyhow!(
+                        "literal secret values must set 'insecure = true' to be used"
+                    ));
+                }
+                Ok(value.clone())
+            }
+        }
+    }
+}
+
+/// A secret's default source, with optional per-environment overrides.
+///
+/// `default` should be a source that's safe to fall back to (e.g. a
+/// production-appropriate file path); `environments` lets a specific
+/// environment (as named by `[targets.*].environment`) use something else,
+/// such as a local file for `dev`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SecretDefinition {
+    pub default: SecretSource,
+    #[serde(default)]
+    pub environments: HashMap<String, SecretSource>,
+}
+
+impl SecretDefinition {
+    fn source_for<'a>(&'a self, environment: &str) -> &'a SecretSource {
+        self.environments.get(environment).unwrap_or(&self.default)
+    }
+}
+
+/// Whether `secret()` should return real values or a masked placeholder.
+///
+/// This only affects what's *returned* to the template — secrets are always
+/// actually resolved, so `migration build`/`test build` still verify a
+/// secret is reachable (and that a `literal` source is marked `insecure`)
+/// even though they mask the result. It's decided once per render, not per
+/// secret: Spawn renders a whole template in a single streaming pass to a
+/// single destination, so there's no case where part of one render should be
+/// masked and another part not. Commands that execute the rendered SQL for
+/// real (`migration apply`, `test run`) always reveal; commands that only
+/// display it for inspection (`migration build`, `test build`) mask by
+/// default.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SecretsRenderMode {
+    Masked,
+    Revealed,
+}
+
+/// A secret's definition paired with its resolved value for the current
+/// render. Bundling the two together means a resolved value is only ever
+/// reachable through the definition that produced it, rather than living in
+/// a second map that merely happens to share keys with the definitions.
+struct Secret {
+    definition: SecretDefinition,
+    // Populated the first time this secret is resolved during a render, so a
+    // secret referenced more than once resolves to the same value even if
+    // its source (e.g. a command) isn't deterministic.
+    resolved: Mutex<Option<String>>,
+}
+
+impl Secret {
+    fn new(definition: SecretDefinition) -> Self {
+        Self {
+            definition,
+            resolved: Mutex::new(None),
+        }
+    }
+
+    async fn resolve(&self, environment: &str, operator: &Operator) -> Result<String> {
+        if let Some(value) = self.resolved.lock().unwrap().as_ref() {
+            return Ok(value.clone());
+        }
+
+        let source = self.definition.source_for(environment);
+        let value = source.resolve(operator).await?;
+
+        *self.resolved.lock().unwrap() = Some(value.clone());
+        Ok(value)
+    }
+}
+
+/// Resolves named secrets against the current environment and render mode.
+pub struct SecretsRepository {
+    secrets: HashMap<String, Secret>,
+    environment: String,
+    mode: SecretsRenderMode,
+    operator: Operator,
+}
+
+impl SecretsRepository {
+    pub fn new(
+        definitions: HashMap<String, SecretDefinition>,
+        environment: String,
+        mode: SecretsRenderMode,
+        operator: Operator,
+    ) -> Self {
+        let secrets = definitions
+            .into_iter()
+            .map(|(name, definition)| (name, Secret::new(definition)))
+            .collect();
+        Self {
+            secrets,
+            environment,
+            mode,
+            operator,
+        }
+    }
+
+    /// A repository with no secrets defined, used where no `spawn.toml`
+    /// secrets config is available (e.g. Spawn's own internal migrations).
+    pub fn empty(operator: Operator) -> Self {
+        Self::new(
+            HashMap::new(),
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            operator,
+        )
+    }
+
+    pub async fn resolve(&self, name: &str) -> Result<String> {
+        let secret = self
+            .secrets
+            .get(name)
+            .ok_or_else(|| anyhow!("no secret named '{}' is defined in spawn.toml", name))?;
+
+        // Always resolve for real, even when masking the result: this is
+        // what lets `build`/`test build` verify a secret is reachable
+        // without ever displaying it.
+        let value = secret
+            .resolve(&self.environment, &self.operator)
+            .await
+            .with_context(|| format!("failed to resolve secret '{}'", name))?;
+
+        Ok(match self.mode {
+            SecretsRenderMode::Masked => format!("***MASKED:{}***", name),
+            SecretsRenderMode::Revealed => value,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::services::Memory;
+
+    fn memory_operator() -> Operator {
+        Operator::new(Memory::default()).unwrap()
+    }
+
+    fn repo(
+        definitions: HashMap<String, SecretDefinition>,
+        environment: &str,
+        mode: SecretsRenderMode,
+    ) -> SecretsRepository {
+        SecretsRepository::new(
+            definitions,
+            environment.to_string(),
+            mode,
+            memory_operator(),
+        )
+    }
+
+    fn defs(entries: Vec<(&str, SecretDefinition)>) -> HashMap<String, SecretDefinition> {
+        entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn resolves_env_source() {
+        std::env::set_var("SPAWN_TEST_SECRET_ENV", "sekrit");
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Env {
+                    name: "SPAWN_TEST_SECRET_ENV".to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Revealed);
+        let value = repository.resolve("application_password").await.unwrap();
+        assert_eq!(value, "sekrit");
+        std::env::remove_var("SPAWN_TEST_SECRET_ENV");
+    }
+
+    #[tokio::test]
+    async fn resolves_file_source_and_strips_trailing_newline() {
+        let op = memory_operator();
+        op.write("secret.txt", "file-secret\n").await.unwrap();
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::File {
+                    path: "secret.txt".to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        let value = repository.resolve("application_password").await.unwrap();
+        assert_eq!(value, "file-secret");
+    }
+
+    #[tokio::test]
+    async fn environment_override_takes_precedence_over_default() {
+        let op = memory_operator();
+        op.write("dev-secret.txt", "dev-value").await.unwrap();
+        op.write("prod-secret.txt", "prod-value").await.unwrap();
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::File {
+                    path: "prod-secret.txt".to_string(),
+                },
+                environments: HashMap::from([(
+                    "dev".to_string(),
+                    SecretSource::File {
+                        path: "dev-secret.txt".to_string(),
+                    },
+                )]),
+            },
+        )]);
+        let repository = SecretsRepository::new(
+            definitions.clone(),
+            "dev".to_string(),
+            SecretsRenderMode::Revealed,
+            op.clone(),
+        );
+        assert_eq!(
+            repository.resolve("application_password").await.unwrap(),
+            "dev-value"
+        );
+
+        let repository = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+        assert_eq!(
+            repository.resolve("application_password").await.unwrap(),
+            "prod-value"
+        );
+    }
+
+    #[tokio::test]
+    async fn masked_mode_hides_a_resolvable_secret() {
+        std::env::set_var("SPAWN_TEST_SECRET_MASKED", "sekrit");
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Env {
+                    name: "SPAWN_TEST_SECRET_MASKED".to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Masked);
+        let value = repository.resolve("application_password").await.unwrap();
+        assert_eq!(value, "***MASKED:application_password***");
+        std::env::remove_var("SPAWN_TEST_SECRET_MASKED");
+    }
+
+    #[tokio::test]
+    async fn masked_mode_still_verifies_the_secret_is_reachable() {
+        // Masking must not skip resolution: this is what lets `build`/`test
+        // build` catch a missing env var (or an insecure literal) without
+        // ever displaying the real value.
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Env {
+                    name: "SPAWN_TEST_SECRET_MISSING".to_string(),
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Masked);
+        let err = repository
+            .resolve("application_password")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("failed to resolve secret"));
+    }
+
+    #[tokio::test]
+    async fn masked_mode_still_rejects_insecure_literal() {
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: false,
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Masked);
+        let err = repository
+            .resolve("application_password")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("failed to resolve secret"));
+    }
+
+    #[tokio::test]
+    async fn missing_secret_definition_errors() {
+        let repository = repo(HashMap::new(), "prod", SecretsRenderMode::Revealed);
+        let err = repository.resolve("nope").await.unwrap_err();
+        assert!(err.to_string().contains("no secret named 'nope'"));
+    }
+
+    #[tokio::test]
+    async fn literal_source_requires_insecure_flag() {
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: false,
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Revealed);
+        let err = repository
+            .resolve("application_password")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("failed to resolve secret"));
+    }
+
+    #[tokio::test]
+    async fn literal_source_with_insecure_flag_resolves() {
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Revealed);
+        assert_eq!(
+            repository.resolve("application_password").await.unwrap(),
+            "hunter2"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_caches_command_source_across_calls() {
+        // Each invocation of `sh -c 'echo $$'` reports a different PID, so
+        // if resolve() weren't caching, two calls would return different
+        // values.
+        let definitions = defs(vec![(
+            "application_password",
+            SecretDefinition {
+                default: SecretSource::Command {
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo $$".to_string()],
+                },
+                environments: HashMap::new(),
+            },
+        )]);
+        let repository = repo(definitions, "prod", SecretsRenderMode::Revealed);
+        let first = repository.resolve("application_password").await.unwrap();
+        let second = repository.resolve("application_password").await.unwrap();
+        assert_eq!(first, second);
+    }
+
+}

--- a/src/sql_formatter/mod.rs
+++ b/src/sql_formatter/mod.rs
@@ -100,6 +100,19 @@ pub fn get_auto_escape_callback(dialect: SqlDialect) -> AutoEscapeCallback {
     }
 }
 
+/// Escapes a raw string the same way this dialect's template auto-escaping
+/// would escape a `String` value, without needing a full minijinja render.
+///
+/// Used to redact both the raw and post-escaping forms of a value that must
+/// never leak (e.g. a secret): some errors echo back a parsed value
+/// (matching the raw form), others echo the submitted SQL text verbatim
+/// (matching this escaped form, quotes and all).
+pub fn escape_string(dialect: SqlDialect, raw: &str) -> String {
+    match dialect {
+        SqlDialect::Postgres => postgres::escape_string(raw),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sql_formatter/postgres.rs
+++ b/src/sql_formatter/postgres.rs
@@ -41,6 +41,14 @@ pub fn auto_escape_callback(_name: &str) -> AutoEscape {
     AutoEscape::Custom(FORMAT_NAME)
 }
 
+/// Escapes a raw string the same way a `String` value would be escaped when
+/// interpolated into a PostgreSQL template — e.g. to redact both the raw and
+/// post-escaping forms of a value that must never leak, without needing a
+/// full minijinja render to produce the escaped form.
+pub fn escape_string(raw: &str) -> String {
+    escape_literal(raw)
+}
+
 /// Recursively formats a minijinja Value for safe PostgreSQL interpolation.
 ///
 /// This handles all ValueKind variants appropriately for PostgreSQL syntax.
@@ -53,10 +61,7 @@ fn format_value_for_postgres(value: &Value) -> Result<String, minijinja::Error> 
             Ok(if b { "TRUE" } else { "FALSE" }.to_string())
         }
         ValueKind::Number => Ok(value.to_string()),
-        ValueKind::String => {
-            let s = value.to_string();
-            Ok(escape_literal(&s))
-        }
+        ValueKind::String => Ok(escape_string(&value.to_string())),
         ValueKind::Bytes => {
             // Convert to PostgreSQL bytea hex format: '\xDEADBEEF'::bytea
             if let Some(bytes) = value.as_bytes() {
@@ -87,13 +92,11 @@ fn format_value_for_postgres(value: &Value) -> Result<String, minijinja::Error> 
             // Maps don't have a native SQL representation.
             // Convert to JSON-like string representation and escape it.
             // Users can cast to ::jsonb if needed: {{ my_map }}::jsonb
-            let s = value.to_string();
-            Ok(escape_literal(&s))
+            Ok(escape_string(&value.to_string()))
         }
         ValueKind::Plain => {
             // For custom objects, stringify and escape as a string
-            let s = value.to_string();
-            Ok(escape_literal(&s))
+            Ok(escape_string(&value.to_string()))
         }
         ValueKind::Invalid => {
             // Invalid values contain errors - propagate them
@@ -105,8 +108,7 @@ fn format_value_for_postgres(value: &Value) -> Result<String, minijinja::Error> 
         // ValueKind is non-exhaustive, handle any future variants safely
         _ => {
             // For unknown types, stringify and escape as a string (safe default)
-            let s = value.to_string();
-            Ok(escape_literal(&s))
+            Ok(escape_string(&value.to_string()))
         }
     }
 }

--- a/src/sqltest/mod.rs
+++ b/src/sqltest/mod.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::engine::EngineError;
+use crate::secrets::SecretsRenderMode;
 use crate::template;
 use console::{style, Style};
 
@@ -51,7 +52,11 @@ impl Tester {
 
     /// Opens the specified script file and generates a test script, compiled
     /// using minijinja.
-    pub async fn generate(&self, variables: Option<crate::variables::Variables>) -> Result<String> {
+    pub async fn generate(
+        &self,
+        variables: Option<crate::variables::Variables>,
+        secrets_mode: SecretsRenderMode,
+    ) -> Result<String> {
         let lock_file = None;
 
         let gen = template::generate_streaming(
@@ -59,6 +64,7 @@ impl Tester {
             lock_file,
             &self.test_file_path(),
             variables,
+            secrets_mode,
         )
         .await?;
 
@@ -72,7 +78,10 @@ impl Tester {
 
     // Runs the test and compares the actual output to expected.
     pub async fn run(&self, variables: Option<crate::variables::Variables>) -> Result<String> {
-        let content = self.generate(variables.clone()).await?;
+        // Tests execute against a real database, so secrets must always be revealed here.
+        let content = self
+            .generate(variables.clone(), SecretsRenderMode::Revealed)
+            .await?;
 
         let engine = self.config.new_engine().await?;
 

--- a/src/sqltest/mod.rs
+++ b/src/sqltest/mod.rs
@@ -78,9 +78,14 @@ impl Tester {
 
     // Runs the test and compares the actual output to expected.
     pub async fn run(&self, variables: Option<crate::variables::Variables>) -> Result<String> {
-        // Tests execute against a real database, so secrets must always be revealed here.
+        // Masked, not revealed: the output here is printed, diffed, and (via
+        // save_expected) committed to the repo, so a real secret value could
+        // end up persisted in an `expected` file or echoed back by a failing
+        // statement's diagnostics. Masking still fully resolves the secret
+        // (so an unreachable/misconfigured one still fails the test), it
+        // just never puts the real value in the SQL sent to the database.
         let content = self
-            .generate(variables.clone(), SecretsRenderMode::Revealed)
+            .generate(variables.clone(), SecretsRenderMode::Masked)
             .await?;
 
         let engine = self.config.new_engine().await?;

--- a/src/store/pinner/mod.rs
+++ b/src/store/pinner/mod.rs
@@ -44,12 +44,21 @@ pub struct Entry {
     pub name: String,
 }
 
-pub async fn pin_contents(fs: &Operator, store_path: &str, contents: &[u8]) -> Result<String> {
+/// Hashes `contents` and, if `store_path` is `Some`, persists it there under
+/// its content-addressed path. Pass `None` to compute the hash without
+/// writing anything — used to fingerprint a tree without actually pinning it.
+pub async fn pin_contents(
+    fs: &Operator,
+    store_path: Option<&str>,
+    contents: &[u8],
+) -> Result<String> {
     let hash = xxhash3_128::Hasher::oneshot(contents);
     let hash = format!("{:032x}", hash);
-    let dir = format!("{}/{}", store_path, hash_to_path(&hash)?);
 
-    fs.write(&dir, contents.to_vec()).await?;
+    if let Some(store_path) = store_path {
+        let dir = format!("{}/{}", store_path, hash_to_path(&hash)?);
+        fs.write(&dir, contents.to_vec()).await?;
+    }
 
     Ok(hash)
 }
@@ -77,8 +86,13 @@ pub(crate) async fn read_hash_file(fs: &Operator, base_path: &str, hash: &str) -
 }
 
 /// Walks through objects in an ObjectStore, creating pinned entries as appropriate for every
-/// directory and file.  Returns a hash of the object.
-pub(crate) async fn snapshot(fs: &Operator, store_path: &str, mut prefix: &str) -> Result<String> {
+/// directory and file.  Returns a hash of the object. Pass `store_path: None` to compute the
+/// hash without persisting anything (used by `Migrator::pin_hash` for `--no-pin` applies).
+pub(crate) async fn snapshot(
+    fs: &Operator,
+    store_path: Option<&str>,
+    mut prefix: &str,
+) -> Result<String> {
     let fixed;
     if !prefix.ends_with("/") {
         fixed = format!("{}/", prefix);
@@ -159,7 +173,7 @@ mod tests {
                 .await?;
 
         let store_loc = "store/";
-        let root = snapshot(&dest_op, store_loc, "components/").await?;
+        let root = snapshot(&dest_op, Some(store_loc), "components/").await?;
 
         assert!(root.len() > 0);
         assert_eq!("cb59728fefa959672ef3c8c9f0b6df95", root);
@@ -175,6 +189,43 @@ mod tests {
         assert_eq!(
             root, content_hash,
             "Snapshot hash should match content hash"
+        );
+
+        Ok(())
+    }
+
+    async fn count_entries(fs: &Operator, prefix: &str) -> Result<usize> {
+        let mut lister = fs.lister_with(prefix).recursive(true).await?;
+        let mut count = 0;
+        while lister.try_next().await?.is_some() {
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_with_no_store_path_matches_real_pin_without_writing() -> Result<()> {
+        let dest_op =
+            store::disk_to_operator("./static/example", None, store::DesiredOperator::Memory)
+                .await?;
+
+        // A real pin against the project's own operator/store path, to compare against.
+        let real_root = snapshot(&dest_op, Some("store/"), "components/").await?;
+        let entry_count_after_real_pin = count_entries(&dest_op, "store/").await?;
+        assert!(
+            entry_count_after_real_pin > 0,
+            "sanity check: real pin should have written something"
+        );
+
+        // store_path: None should produce the same hash...
+        let simulated_root = snapshot(&dest_op, None, "components/").await?;
+        assert_eq!(real_root, simulated_root);
+
+        // ...without having persisted anything as a side effect of computing it.
+        let entry_count_after_simulated = count_entries(&dest_op, "store/").await?;
+        assert_eq!(
+            entry_count_after_real_pin, entry_count_after_simulated,
+            "computing the hash with store_path: None should not have written any new entries"
         );
 
         Ok(())

--- a/src/store/pinner/mod.rs
+++ b/src/store/pinner/mod.rs
@@ -73,14 +73,33 @@ pub fn hash_to_path(hash: &str) -> Result<String> {
     Ok(format!("{}/{}", first_two, rest).to_string())
 }
 
+/// Recomputes the content hash of `contents` and errors if it doesn't match
+/// `expected`. Pinned storage is content-addressed by construction, so a
+/// mismatch means the file at `path` was modified (or corrupted) on disk
+/// after it was pinned — trust the hash over whatever bytes are found there.
+pub(crate) fn verify_hash(contents: &[u8], expected: &str, path: &str) -> Result<()> {
+    let actual = format!("{:032x}", xxhash3_128::Hasher::oneshot(contents));
+    if actual != expected {
+        return Err(anyhow::anyhow!(
+            "pinned file '{}' does not match its expected hash '{}' (got '{}') — \
+             its contents appear to have been modified since it was pinned",
+            path,
+            expected,
+            actual
+        ));
+    }
+    Ok(())
+}
+
 /// Reads the file corresponding to the hash from the given base path.
 pub(crate) async fn read_hash_file(fs: &Operator, base_path: &str, hash: &str) -> Result<String> {
     let relative_path = hash_to_path(hash)?;
     let file_path = format!("{}/{}", base_path, relative_path);
 
     let get_result = fs.read(&file_path).await?;
-    let bytes = get_result.to_bytes();
-    let contents = String::from_utf8(bytes.to_vec())?;
+    let bytes = get_result.to_bytes().to_vec();
+    verify_hash(&bytes, hash, &file_path)?;
+    let contents = String::from_utf8(bytes)?;
 
     Ok(contents)
 }

--- a/src/store/pinner/spawn.rs
+++ b/src/store/pinner/spawn.rs
@@ -110,6 +110,6 @@ impl Pinner for Spawn {
     }
 
     async fn snapshot(&mut self, object_store: &Operator) -> Result<String> {
-        super::snapshot(object_store, &self.pin_path, &self.source_path).await
+        super::snapshot(object_store, Some(self.pin_path.as_str()), &self.source_path).await
     }
 }

--- a/src/store/pinner/spawn.rs
+++ b/src/store/pinner/spawn.rs
@@ -7,9 +7,18 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Spawn {
-    files: Option<HashMap<String, String>>,
+    files: Option<HashMap<String, PinnedFile>>,
     pin_path: String,
     source_path: String,
+}
+
+/// Where a pinned file's contents live, and the hash its path is supposed to
+/// correspond to — kept alongside the path so a load can verify the two
+/// still agree.
+#[derive(Debug, Clone)]
+struct PinnedFile {
+    path: String,
+    hash: String,
 }
 
 impl Spawn {
@@ -44,7 +53,7 @@ impl Spawn {
     async fn read_root_hash(
         object_store: &Operator,
         store_path: &str,
-        files: &mut HashMap<String, String>,
+        files: &mut HashMap<String, PinnedFile>,
         base_path: &str,
         root_hash: &str,
     ) -> Result<()> {
@@ -62,7 +71,13 @@ impl Spawn {
                         format!("{}/{}", base_path, &entry.name)
                     };
                     let full_path = format!("{}/{}", store_path, super::hash_to_path(&entry.hash)?);
-                    files.insert(full_name, full_path);
+                    files.insert(
+                        full_name,
+                        PinnedFile {
+                            path: full_path,
+                            hash: entry.hash.clone(),
+                        },
+                    );
                 }
                 super::EntryKind::Tree => {
                     let new_base = if base_path.is_empty() {
@@ -96,11 +111,12 @@ impl Pinner for Spawn {
             .as_ref()
             .ok_or(anyhow!("files not initialized, was a root hash specified?"))?;
 
-        if let Some(path) = files.get(name) {
-            match object_store.read(path).await {
+        if let Some(pinned) = files.get(name) {
+            match object_store.read(&pinned.path).await {
                 Ok(get_result) => {
-                    let bytes = get_result.to_bytes();
-                    Ok(Some(bytes.to_vec()))
+                    let bytes = get_result.to_bytes().to_vec();
+                    super::verify_hash(&bytes, &pinned.hash, &pinned.path)?;
+                    Ok(Some(bytes))
                 }
                 Err(_) => Ok(None),
             }

--- a/src/template.rs
+++ b/src/template.rs
@@ -23,7 +23,7 @@ use twox_hash::xxhash3_128;
 /// Multiple engine types may share the same dialect. For example,
 /// both a psql CLI engine and a native PostgreSQL driver would use
 /// the Postgres dialect.
-fn engine_to_dialect(engine: &EngineType) -> SqlDialect {
+pub(crate) fn engine_to_dialect(engine: &EngineType) -> SqlDialect {
     match engine {
         EngineType::PostgresPSQL => SqlDialect::Postgres,
         // Future engines:

--- a/src/template.rs
+++ b/src/template.rs
@@ -764,6 +764,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_secret_function_escapes_injection_attempt_when_revealed() {
+        use std::collections::HashMap;
+
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            crate::secrets::SecretDefinition {
+                default: crate::secrets::SecretSource::Literal {
+                    value: "'; DROP TABLE users; --".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+
+        let mut env = env_with_secrets(secrets);
+        env.add_template(
+            "test.sql",
+            r#"CREATE ROLE app_user WITH LOGIN PASSWORD {{ secret("application_password") }};"#,
+        )
+        .unwrap();
+        let tmpl = env.get_template("test.sql").unwrap();
+        let result = tmpl.render(context!()).unwrap();
+        assert_eq!(
+            result,
+            "CREATE ROLE app_user WITH LOGIN PASSWORD '''; DROP TABLE users; --';"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_secret_function_masks_when_masked_mode() {
         use std::collections::HashMap;
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -873,4 +873,93 @@ mod tests {
         let result = tmpl.render(context!());
         assert!(result.is_err());
     }
+
+    fn streaming_generation(template_contents: &str, secrets: SecretsRepository) -> StreamingGeneration {
+        use crate::config::FolderPather;
+        use opendal::services::Memory;
+        use opendal::Operator;
+
+        let op = Operator::new(Memory::default()).unwrap();
+        let pinner = Latest::new("").unwrap();
+        let pather = FolderPather {
+            spawn_folder: "".to_string(),
+        };
+        let store = Store::new(Box::new(pinner), op, pather).unwrap();
+
+        StreamingGeneration {
+            store,
+            template_contents: template_contents.to_string(),
+            environment: "prod".to_string(),
+            variables: crate::variables::Variables::default(),
+            engine: EngineType::PostgresPSQL,
+            secrets: Arc::new(secrets),
+        }
+    }
+
+    fn literal_secret_repo(value: &str) -> SecretsRepository {
+        use std::collections::HashMap;
+
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            crate::secrets::SecretDefinition {
+                default: crate::secrets::SecretSource::Literal {
+                    value: value.to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        )
+    }
+
+    // Regression coverage for the checksum's security-critical properties
+    // (see StreamingGeneration::raw_checksum's doc comment): it must be a
+    // fingerprint of the raw template source specifically — not the
+    // rendered output, and not something secret-independent-but-otherwise-
+    // arbitrary either — so a future change can't silently start hashing
+    // rendered SQL (and disclose secret values via the checksum) again.
+
+    #[test]
+    fn raw_checksum_matches_a_hash_of_the_raw_template_source() {
+        let source = r#"SELECT {{ secret("application_password") }};"#;
+        let gen = streaming_generation(source, literal_secret_repo("hunter2"));
+
+        let expected = format!(
+            "{:032x}",
+            twox_hash::xxhash3_128::Hasher::oneshot(source.as_bytes())
+        );
+        assert_eq!(gen.raw_checksum(), expected);
+    }
+
+    #[test]
+    fn raw_checksum_is_unchanged_by_a_rotated_secret_value() {
+        let source = r#"SELECT {{ secret("application_password") }};"#;
+        let gen_a = streaming_generation(source, literal_secret_repo("hunter2"));
+        let gen_b = streaming_generation(source, literal_secret_repo("a-totally-different-value"));
+
+        assert_eq!(
+            gen_a.raw_checksum(),
+            gen_b.raw_checksum(),
+            "rotating a secret's resolved value must not change the recorded checksum"
+        );
+    }
+
+    #[test]
+    fn raw_checksum_changes_when_the_template_source_changes() {
+        let gen_a = streaming_generation("SELECT 1;", literal_secret_repo("hunter2"));
+        let gen_b = streaming_generation("SELECT 2;", literal_secret_repo("hunter2"));
+
+        assert_ne!(
+            gen_a.raw_checksum(),
+            gen_b.raw_checksum(),
+            "different up.sql content must produce different checksums"
+        );
+    }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -321,6 +321,13 @@ pub struct StreamingGeneration {
     variables: Variables,
     engine: EngineType,
     secrets: Arc<SecretsRepository>,
+    /// The pin loaded from lock.toml to build this render's component
+    /// store (`None` when generated with `--no-pin`), captured at the same
+    /// time that lock is read — a caller recording it to migration_history
+    /// should use this instead of re-reading lock.toml, which could race a
+    /// concurrent re-pin and record a hash that doesn't match what was
+    /// actually rendered.
+    pin_hash: Option<String>,
 }
 
 impl StreamingGeneration {
@@ -335,6 +342,13 @@ impl StreamingGeneration {
     pub fn raw_checksum(&self) -> String {
         let hash = xxhash3_128::Hasher::oneshot(self.template_contents.as_bytes());
         format!("{:032x}", hash)
+    }
+
+    /// The pin actually used to build this render's component store — see
+    /// the `pin_hash` field doc comment for why this should be preferred
+    /// over separately re-reading lock.toml.
+    pub fn pin_hash(&self) -> Option<&str> {
+        self.pin_hash.as_deref()
     }
 
     /// Render the template to the provided writer.
@@ -375,7 +389,8 @@ pub async fn generate_streaming(
     variables: Option<Variables>,
     secrets_mode: SecretsRenderMode,
 ) -> Result<StreamingGeneration> {
-    let pinner: Box<dyn Pinner> = if let Some(lock_file) = lock_file {
+    let (pinner, pin_hash): (Box<dyn Pinner>, Option<String>) = if let Some(lock_file) = lock_file
+    {
         let lock = cfg
             .load_lock_file(&lock_file)
             .await
@@ -388,10 +403,10 @@ pub async fn generate_streaming(
         )
         .await
         .context("could not get new root with hash")?;
-        Box::new(pinner)
+        (Box::new(pinner), Some(lock.pin))
     } else {
         let pinner = Latest::new(cfg.pather().spawn_folder_path())?;
-        Box::new(pinner)
+        (Box::new(pinner), None)
     };
 
     let store = Store::new(pinner, cfg.operator().clone(), cfg.pather())
@@ -413,6 +428,7 @@ pub async fn generate_streaming(
         &target_config.engine,
         store,
         secrets,
+        pin_hash,
     )
     .await
 }
@@ -425,6 +441,7 @@ pub async fn generate_streaming_with_store(
     engine: &EngineType,
     store: Store,
     secrets: SecretsRepository,
+    pin_hash: Option<String>,
 ) -> Result<StreamingGeneration> {
     // Read contents from our object store first:
     let contents = store
@@ -439,6 +456,7 @@ pub async fn generate_streaming_with_store(
         variables: variables.unwrap_or_default(),
         engine: engine.clone(),
         secrets: Arc::new(secrets),
+        pin_hash,
     })
 }
 
@@ -893,6 +911,7 @@ mod tests {
             variables: crate::variables::Variables::default(),
             engine: EngineType::PostgresPSQL,
             secrets: Arc::new(secrets),
+            pin_hash: None,
         }
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use anyhow::{Context, Result};
 use minijinja::context;
 use std::sync::Arc;
+use twox_hash::xxhash3_128;
 
 /// Maps an EngineType to the appropriate SQL dialect for formatting.
 ///
@@ -187,6 +188,17 @@ fn secret_function(
 }
 
 /// Reads raw bytes from a file in the components folder via the Store.
+///
+/// IDEA (not implemented): `read_file`/`read_json`/etc. re-fetch and
+/// re-parse their input on every call, with no memoization across separate
+/// render() invocations of the same template. minijinja's `Value` is
+/// Arc-backed internally for its String/Bytes/Object variants (see
+/// minijinja::value::ValueRepr), so cloning an already-built `Value` is
+/// cheap — a filter-level cache keyed by input (e.g. on `Store`) could let
+/// a second render of the same migration reuse an already-loaded large
+/// file via a cheap Arc clone instead of re-fetching/re-parsing it. Only
+/// worth building if a real need for multi-render or repeated large-file
+/// loads comes up; nothing currently requires it.
 fn read_file_bytes(path: &str, store: &Arc<Store>) -> Result<Vec<u8>, minijinja::Error> {
     let bytes = tokio::task::block_in_place(|| {
         tokio::runtime::Handle::current().block_on(async { store.read_file_bytes(path).await })
@@ -313,6 +325,19 @@ pub struct StreamingGeneration {
 }
 
 impl StreamingGeneration {
+    /// Hex-encoded fingerprint of the migration's raw (unrendered) template
+    /// source, for use as a migration_history audit-trail checksum.
+    ///
+    /// Deliberately hashes the raw source rather than the rendered output:
+    /// rendered SQL may contain resolved secret values, which must never be
+    /// persisted (or reconstructible from what's persisted) via the
+    /// checksum. As a side effect, this also means secret rotation never
+    /// changes a migration's recorded checksum.
+    pub fn raw_checksum(&self) -> String {
+        let hash = xxhash3_128::Hasher::oneshot(self.template_contents.as_bytes());
+        format!("{:032x}", hash)
+    }
+
     /// Render the template to the provided writer.
     /// This creates the minijinja environment and renders in one step.
     pub fn render_to_writer<W: std::io::Write + ?Sized>(self, writer: &mut W) -> Result<()> {
@@ -686,7 +711,7 @@ mod tests {
         op.write("components/test.txt", "pinned content")
             .await
             .unwrap();
-        let root_hash = snapshot(&op, "pinned/", "components/").await.unwrap();
+        let root_hash = snapshot(&op, Some("pinned/"), "components/").await.unwrap();
 
         // Delete the original file so it only exists in the pinned CAS store
         op.delete("components/test.txt").await.unwrap();

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::engine::EngineType;
 use crate::escape::{EscapedIdentifier, EscapedLiteral};
+use crate::secrets::{SecretsRenderMode, SecretsRepository};
 use crate::store::pinner::latest::Latest;
 use crate::store::pinner::spawn::Spawn;
 use crate::store::pinner::Pinner;
@@ -31,7 +32,11 @@ fn engine_to_dialect(engine: &EngineType) -> SqlDialect {
     }
 }
 
-pub fn template_env(store: Store, engine: &EngineType) -> Result<Environment<'static>> {
+pub fn template_env(
+    store: Store,
+    engine: &EngineType,
+    secrets: SecretsRepository,
+) -> Result<Environment<'static>> {
     let mut env = Environment::new();
 
     let store = Arc::new(store);
@@ -45,6 +50,12 @@ pub fn template_env(store: Store, engine: &EngineType) -> Result<Environment<'st
     env.add_function("gen_uuid_v7", gen_uuid_v7);
     env.add_filter("escape_identifier", escape_identifier_filter);
     env.add_filter("escape_literal", escape_literal_filter);
+
+    let secrets = Arc::new(secrets);
+    env.add_function(
+        "secret",
+        move |name: &str| -> Result<Value, minijinja::Error> { secret_function(name, &secrets) },
+    );
 
     let read_file_store = Arc::clone(&store);
     env.add_filter(
@@ -156,6 +167,23 @@ fn escape_literal_filter(value: &Value) -> Result<Value, minijinja::Error> {
     let escaped = EscapedLiteral::new(&s);
     // Return as a safe string so it won't be further escaped by the SQL formatter
     Ok(Value::from_safe_string(escaped.to_string()))
+}
+
+/// Resolves a named secret via the SecretsRepository, returning either its
+/// real value or a masked placeholder depending on the current render mode.
+///
+/// Usage in templates: `{{ secret("application_password") }}`
+fn secret_function(
+    name: &str,
+    secrets: &Arc<SecretsRepository>,
+) -> Result<Value, minijinja::Error> {
+    let result = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async { secrets.resolve(name).await })
+    });
+
+    result.map(Value::from).map_err(|e| {
+        minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, format!("{:#}", e))
+    })
 }
 
 /// Reads raw bytes from a file in the components folder via the Store.
@@ -281,13 +309,14 @@ pub struct StreamingGeneration {
     environment: String,
     variables: Variables,
     engine: EngineType,
+    secrets: SecretsRepository,
 }
 
 impl StreamingGeneration {
     /// Render the template to the provided writer.
     /// This creates the minijinja environment and renders in one step.
     pub fn render_to_writer<W: std::io::Write + ?Sized>(self, writer: &mut W) -> Result<()> {
-        let mut env = template_env(self.store, &self.engine)?;
+        let mut env = template_env(self.store, &self.engine, self.secrets)?;
         env.add_template("migration.sql", &self.template_contents)?;
         let tmpl = env.get_template("migration.sql")?;
         tmpl.render_to_write(
@@ -313,6 +342,7 @@ pub async fn generate_streaming(
     lock_file: Option<String>,
     name: &str,
     variables: Option<Variables>,
+    secrets_mode: SecretsRenderMode,
 ) -> Result<StreamingGeneration> {
     let pinner: Box<dyn Pinner> = if let Some(lock_file) = lock_file {
         let lock = cfg
@@ -338,6 +368,12 @@ pub async fn generate_streaming(
     let target_config = cfg
         .target_config()
         .context("could not get target config for generate")?;
+    let secrets = SecretsRepository::new(
+        cfg.secrets.clone(),
+        target_config.environment.clone(),
+        secrets_mode,
+        cfg.operator().clone(),
+    );
 
     generate_streaming_with_store(
         name,
@@ -345,6 +381,7 @@ pub async fn generate_streaming(
         &target_config.environment,
         &target_config.engine,
         store,
+        secrets,
     )
     .await
 }
@@ -356,6 +393,7 @@ pub async fn generate_streaming_with_store(
     environment: &str,
     engine: &EngineType,
     store: Store,
+    secrets: SecretsRepository,
 ) -> Result<StreamingGeneration> {
     // Read contents from our object store first:
     let contents = store
@@ -369,6 +407,7 @@ pub async fn generate_streaming_with_store(
         environment: environment.to_string(),
         variables: variables.unwrap_or_default(),
         engine: engine.clone(),
+        secrets,
     })
 }
 
@@ -559,9 +598,10 @@ mod tests {
         let pather = FolderPather {
             spawn_folder: "".to_string(),
         };
+        let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "test.txt"|read_file|to_string_lossy|safe }}"#,
@@ -589,9 +629,10 @@ mod tests {
         let pather = FolderPather {
             spawn_folder: "".to_string(),
         };
+        let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "binary.dat"|read_file|base64_encode|safe }}"#,
@@ -616,9 +657,10 @@ mod tests {
         let pather = FolderPather {
             spawn_folder: "".to_string(),
         };
+        let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "nonexistent.txt"|read_file|to_string_lossy }}"#,
@@ -662,9 +704,10 @@ mod tests {
         let pather = FolderPather {
             spawn_folder: "".to_string(),
         };
+        let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "test.txt"|read_file|to_string_lossy|safe }}"#,
@@ -673,5 +716,93 @@ mod tests {
         let tmpl = env.get_template("test.sql").unwrap();
         let result = tmpl.render(context!()).unwrap();
         assert_eq!(result, "pinned content");
+    }
+
+    fn env_with_secrets(secrets: SecretsRepository) -> Environment<'static> {
+        use crate::config::FolderPather;
+        use opendal::services::Memory;
+        use opendal::Operator;
+
+        let op = Operator::new(Memory::default()).unwrap();
+        let pinner = Latest::new("").unwrap();
+        let pather = FolderPather {
+            spawn_folder: "".to_string(),
+        };
+        let store = Store::new(Box::new(pinner), op, pather).unwrap();
+        template_env(store, &EngineType::PostgresPSQL, secrets).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_secret_function_reveals_when_revealed_mode() {
+        use std::collections::HashMap;
+
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            crate::secrets::SecretDefinition {
+                default: crate::secrets::SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Revealed,
+            op,
+        );
+
+        let mut env = env_with_secrets(secrets);
+        env.add_template("test.sql", r#"{{ secret("application_password") }}"#)
+            .unwrap();
+        let tmpl = env.get_template("test.sql").unwrap();
+        let result = tmpl.render(context!()).unwrap();
+        assert_eq!(result, "'hunter2'");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_secret_function_masks_when_masked_mode() {
+        use std::collections::HashMap;
+
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let mut definitions = HashMap::new();
+        definitions.insert(
+            "application_password".to_string(),
+            crate::secrets::SecretDefinition {
+                default: crate::secrets::SecretSource::Literal {
+                    value: "hunter2".to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let secrets = SecretsRepository::new(
+            definitions,
+            "prod".to_string(),
+            SecretsRenderMode::Masked,
+            op,
+        );
+
+        let mut env = env_with_secrets(secrets);
+        env.add_template("test.sql", r#"{{ secret("application_password") }}"#)
+            .unwrap();
+        let tmpl = env.get_template("test.sql").unwrap();
+        let result = tmpl.render(context!()).unwrap();
+        assert_eq!(result, "'***MASKED:application_password***'");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_secret_function_errors_for_unknown_secret() {
+        let op = opendal::Operator::new(opendal::services::Memory::default()).unwrap();
+        let secrets = SecretsRepository::empty(op);
+        let mut env = env_with_secrets(secrets);
+        env.add_template("test.sql", r#"{{ secret("nope") }}"#)
+            .unwrap();
+        let tmpl = env.get_template("test.sql").unwrap();
+        let result = tmpl.render(context!());
+        assert!(result.is_err());
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -36,7 +36,7 @@ fn engine_to_dialect(engine: &EngineType) -> SqlDialect {
 pub fn template_env(
     store: Store,
     engine: &EngineType,
-    secrets: SecretsRepository,
+    secrets: Arc<SecretsRepository>,
 ) -> Result<Environment<'static>> {
     let mut env = Environment::new();
 
@@ -52,7 +52,6 @@ pub fn template_env(
     env.add_filter("escape_identifier", escape_identifier_filter);
     env.add_filter("escape_literal", escape_literal_filter);
 
-    let secrets = Arc::new(secrets);
     env.add_function(
         "secret",
         move |name: &str| -> Result<Value, minijinja::Error> { secret_function(name, &secrets) },
@@ -321,7 +320,7 @@ pub struct StreamingGeneration {
     environment: String,
     variables: Variables,
     engine: EngineType,
-    secrets: SecretsRepository,
+    secrets: Arc<SecretsRepository>,
 }
 
 impl StreamingGeneration {
@@ -351,12 +350,19 @@ impl StreamingGeneration {
         Ok(())
     }
 
-    /// Convert this streaming generation into a WriterFn that can be passed to migration_apply.
-    pub fn into_writer_fn(self) -> crate::engine::WriterFn {
-        Box::new(move |writer: &mut dyn std::io::Write| {
+    /// Convert this streaming generation into a WriterFn that can be passed
+    /// to migration_apply, along with a handle to the same secrets
+    /// repository the render will use. That handle stays readable after the
+    /// closure runs (e.g. once psql has exited), so a caller whose apply
+    /// failed can find out which secret values were actually resolved and
+    /// redact them from captured output before it's displayed or logged.
+    pub fn into_writer_fn(self) -> (crate::engine::WriterFn, Arc<SecretsRepository>) {
+        let secrets = Arc::clone(&self.secrets);
+        let write_fn = Box::new(move |writer: &mut dyn std::io::Write| {
             self.render_to_writer(writer)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-        })
+        });
+        (write_fn, secrets)
     }
 }
 
@@ -432,7 +438,7 @@ pub async fn generate_streaming_with_store(
         environment: environment.to_string(),
         variables: variables.unwrap_or_default(),
         engine: engine.clone(),
-        secrets,
+        secrets: Arc::new(secrets),
     })
 }
 
@@ -626,7 +632,7 @@ mod tests {
         let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, Arc::new(secrets)).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "test.txt"|read_file|to_string_lossy|safe }}"#,
@@ -657,7 +663,7 @@ mod tests {
         let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, Arc::new(secrets)).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "binary.dat"|read_file|base64_encode|safe }}"#,
@@ -685,7 +691,7 @@ mod tests {
         let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, Arc::new(secrets)).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "nonexistent.txt"|read_file|to_string_lossy }}"#,
@@ -732,7 +738,7 @@ mod tests {
         let secrets = SecretsRepository::empty(op.clone());
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
 
-        let mut env = template_env(store, &EngineType::PostgresPSQL, secrets).unwrap();
+        let mut env = template_env(store, &EngineType::PostgresPSQL, Arc::new(secrets)).unwrap();
         env.add_template(
             "test.sql",
             r#"{{ "test.txt"|read_file|to_string_lossy|safe }}"#,
@@ -754,7 +760,7 @@ mod tests {
             spawn_folder: "".to_string(),
         };
         let store = Store::new(Box::new(pinner), op, pather).unwrap();
-        template_env(store, &EngineType::PostgresPSQL, secrets).unwrap()
+        template_env(store, &EngineType::PostgresPSQL, Arc::new(secrets)).unwrap()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -1615,11 +1615,41 @@ async fn test_migration_history_records_expected_checksum_and_pin_hash() -> Resu
     retry_apply(&config, &migration_name, false).await?;
     assert_latest_row("3", &checksum, &pin_hash)?;
 
-    // Pinning and re-applying pinned must change the pin_hash to the real
-    // lock.toml value, without touching the checksum (up.sql is unchanged).
-    let pin_hash = helper.migration_helper.pin_migration(&migration_name).await?;
+    // Adding a component, pinning, then editing the component *again*
+    // diverges the live tree from what's frozen in lock.toml. A pinned
+    // apply must record the frozen (pinned) value, not a fresh live
+    // recompute — proving apply actually reads lock.toml here, not just
+    // that pinning changes something. Without the second edit, live and
+    // pinned would still agree at apply time even if apply's pinned path
+    // regressed to reusing the unpinned computation instead.
+    let component_path = format!("{}/placeholder.sql", config.pather().components_folder());
+    helper
+        .migration_helper
+        .fs
+        .write(&component_path, "-- component v1")
+        .await?;
+    let pinned_hash = helper.migration_helper.pin_migration(&migration_name).await?;
+    assert_ne!(
+        pin_hash, pinned_hash,
+        "test setup error: adding a component should have changed the pin hash"
+    );
+
+    helper
+        .migration_helper
+        .fs
+        .write(&component_path, "-- component v2")
+        .await?;
+    let live_hash_after_pin = Migrator::new(&config, &migration_name, false)
+        .recompute_pin_hash()
+        .await?;
+    assert_ne!(
+        pinned_hash, live_hash_after_pin,
+        "test setup error: editing the component again after pinning should diverge \
+         the live tree from what's frozen in lock.toml"
+    );
+
     retry_apply(&config, &migration_name, true).await?;
-    assert_latest_row("4", &checksum, &pin_hash)?;
+    assert_latest_row("4", &checksum, &pinned_hash)?;
 
     Ok(())
 }

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -1624,6 +1624,68 @@ async fn test_migration_history_records_expected_checksum_and_pin_hash() -> Resu
     Ok(())
 }
 
+/// `test run` (and by extension `compare`/`expect`, which build on it) must
+/// mask secrets by default: its output is printed, diffed, and — via `test
+/// expect` — committed to the repo, so a revealed secret risks both a
+/// transient leak (a failing statement's diagnostics) and a permanent one
+/// (baked into a checked-in `expected` file).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore]
+async fn test_test_run_masks_secrets_by_default() -> Result<()> {
+    require_postgres()?;
+
+    let helper =
+        IntegrationTestHelper::new("test_test_run_masks_secrets_by_default", None).await?;
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "application_password".to_string(),
+        SecretDefinition {
+            default: SecretSource::Literal {
+                value: "hunter2-distinctive".to_string(),
+                insecure: true,
+            },
+            environments: HashMap::new(),
+        },
+    );
+    let mut config_loader =
+        IntegrationTestHelper::create_config(&helper.db_name, &helper.connection_mode);
+    config_loader.secrets = Some(secrets);
+    config_loader
+        .save(
+            helper.migration_helper.config_path(),
+            &helper.migration_helper.fs,
+        )
+        .await?;
+
+    let test_name = helper.migration_helper.create_test("secret-test").await?;
+    let config = helper.migration_helper.load_config().await?;
+    helper
+        .migration_helper
+        .fs
+        .write(
+            &config.pather().test_file_path(&test_name),
+            "SELECT {{ secret(\"application_password\") }};",
+        )
+        .await?;
+
+    let tester = spawn_db::sqltest::Tester::new(&config, &test_name);
+    let output = tester.run(None).await?;
+
+    assert!(
+        !output.contains("hunter2-distinctive"),
+        "test run output should not contain the real secret value, got: {}",
+        output
+    );
+    assert!(
+        output.contains("***MASKED:application_password***"),
+        "expected the masked placeholder in test run output, got: {}",
+        output
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 #[ignore]
 async fn test_cli_test_compare() -> Result<()> {

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -1584,7 +1584,7 @@ async fn test_migration_history_records_expected_checksum_and_pin_hash() -> Resu
         .generate_streaming(None, SecretsRenderMode::Masked)
         .await?
         .raw_checksum();
-    let pin_hash = mgrtr.pin_hash().await?;
+    let pin_hash = mgrtr.recompute_pin_hash().await?;
     assert_latest_row("1", &checksum, &pin_hash)?;
 
     // Rotating the secret and re-applying must leave both columns unchanged.

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -44,7 +44,8 @@ use spawn_db::{
     commands::{AdoptMigration, ApplyMigration, Command, CompareTests, ExpectTest, Outcome},
     config::ConfigLoaderSaver,
     engine::{CommandSpec, EngineType, TargetConfig},
-    secrets::{SecretDefinition, SecretSource},
+    migrator::Migrator,
+    secrets::{SecretDefinition, SecretSource, SecretsRenderMode},
 };
 use std::collections::HashMap;
 use std::env;
@@ -1418,8 +1419,7 @@ async fn test_apply_error_redacts_resolved_secret_values() -> Result<()> {
     require_postgres()?;
 
     let helper =
-        IntegrationTestHelper::new("test_apply_error_redacts_resolved_secret_values", None)
-            .await?;
+        IntegrationTestHelper::new("test_apply_error_redacts_resolved_secret_values", None).await?;
 
     let secret_value = "hunter2-distinctive-secret-value";
     let mut secrets = HashMap::new();
@@ -1437,15 +1437,17 @@ async fn test_apply_error_redacts_resolved_secret_values() -> Result<()> {
         IntegrationTestHelper::create_config(&helper.db_name, &helper.connection_mode);
     config_loader.secrets = Some(secrets);
     config_loader
-        .save(helper.migration_helper.config_path(), &helper.migration_helper.fs)
+        .save(
+            helper.migration_helper.config_path(),
+            &helper.migration_helper.fs,
+        )
         .await?;
 
     // Casting the secret to an integer guarantees Postgres echoes the exact
     // literal back in its own error message ("invalid input syntax for type
     // integer: \"...\""), independent of any table/constraint setup.
-    let bad_migration = format!(
-        "BEGIN;\n\nSELECT {{{{ secret(\"application_password\") }}}}::integer;\n\nCOMMIT;"
-    );
+    let bad_migration =
+        format!("BEGIN;\n\nSELECT {{{{ secret(\"application_password\") }}}}::integer;\n\nCOMMIT;");
     let migration_name = helper
         .migration_helper
         .create_migration_manual("secret-then-fail", bad_migration)
@@ -1469,6 +1471,212 @@ async fn test_apply_error_redacts_resolved_secret_values() -> Result<()> {
         full_text.contains("invalid input syntax"),
         "redaction should not have destroyed the rest of the error's useful detail, got: {}",
         full_text
+    );
+
+    Ok(())
+}
+
+/// migration_history.checksum must fingerprint the raw, unrendered up.sql —
+/// never the rendered SQL, which would embed resolved secret values (see
+/// StreamingGeneration::raw_checksum's doc comment, and the template.rs unit
+/// tests for the pure-function version of this property). This exercises
+/// the real `apply` pipeline end to end.
+#[tokio::test]
+#[ignore]
+async fn test_migration_history_checksum_is_raw_source_and_secret_rotation_invariant() -> Result<()>
+{
+    require_postgres()?;
+
+    let helper = IntegrationTestHelper::new(
+        "test_migration_history_checksum_is_raw_source_and_secret_rotation_invariant",
+        None,
+    )
+    .await?;
+
+    let save_secret = |value: &str| {
+        let mut secrets = HashMap::new();
+        secrets.insert(
+            "application_password".to_string(),
+            SecretDefinition {
+                default: SecretSource::Literal {
+                    value: value.to_string(),
+                    insecure: true,
+                },
+                environments: HashMap::new(),
+            },
+        );
+        let mut config_loader =
+            IntegrationTestHelper::create_config(&helper.db_name, &helper.connection_mode);
+        config_loader.secrets = Some(secrets);
+        config_loader
+    };
+
+    save_secret("hunter2")
+        .save(
+            helper.migration_helper.config_path(),
+            &helper.migration_helper.fs,
+        )
+        .await?;
+
+    // A plain SELECT has no side effects, so re-applying it via --retry
+    // below is trivially safe to repeat.
+    let migration_content =
+        "BEGIN;\n\nSELECT {{ secret(\"application_password\") }}::text;\n\nCOMMIT;";
+    let migration_name = helper
+        .migration_helper
+        .create_migration_manual("checksum-rotation", migration_content.to_string())
+        .await?;
+
+    helper.apply_migration(&migration_name).await?;
+
+    // Computed via the same production code path `apply` uses, independent
+    // of the round trip through the database.
+    let config = helper.migration_helper.load_config().await?;
+    let expected_checksum = Migrator::new(&config, &migration_name, false)
+        .generate_streaming(None, SecretsRenderMode::Masked)
+        .await?
+        .raw_checksum();
+
+    let checksum_query = format!(
+        "SELECT encode(mh.checksum, 'hex') FROM _spawn.migration m \
+         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
+         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
+        migration_name
+    );
+    let history_count_query = format!(
+        "SELECT COUNT(*) FROM _spawn.migration m \
+         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
+         WHERE m.name = '{}';",
+        migration_name
+    );
+
+    let first_checksum = helper.execute_sql(&checksum_query)?;
+    assert!(
+        first_checksum.contains(&expected_checksum),
+        "expected checksum '{}' in result, got: {}",
+        expected_checksum,
+        first_checksum
+    );
+    let history_count_after_first = helper.execute_sql(&history_count_query)?;
+    assert!(
+        history_count_after_first.contains("1"),
+        "expected exactly 1 history row after the first apply, got: {}",
+        history_count_after_first
+    );
+
+    // Rotate the secret's value and re-apply the same up.sql — the checksum
+    // must not move.
+    save_secret("a-totally-different-value")
+        .save(
+            helper.migration_helper.config_path(),
+            &helper.migration_helper.fs,
+        )
+        .await?;
+
+    let config = helper.migration_helper.load_config().await?;
+    let cmd = ApplyMigration {
+        migration: Some(migration_name.clone()),
+        pinned: false,
+        variables: None,
+        yes: true,
+        retry: true,
+        reuse_connection: false,
+    };
+    cmd.execute(&config).await?;
+
+    // Prove the retry actually recorded a second row rather than the
+    // checksum query below just re-reading the first one — otherwise this
+    // test would pass even if --retry silently no-op'd.
+    let history_count_after_retry = helper.execute_sql(&history_count_query)?;
+    assert!(
+        history_count_after_retry.contains("2"),
+        "expected exactly 2 history rows after the --retry apply, got: {}",
+        history_count_after_retry
+    );
+
+    let second_checksum = helper.execute_sql(&checksum_query)?;
+    assert!(
+        second_checksum.contains(&expected_checksum),
+        "checksum changed after rotating the secret's value, expected '{}' in: {}",
+        expected_checksum,
+        second_checksum
+    );
+
+    Ok(())
+}
+
+/// migration_history.pin_hash must record the actual component-tree hash
+/// used to render the migration — the real pinned hash from lock.toml when
+/// pinned, or the equivalent hash of the current tree when applied with
+/// --no-pin. The previous test coverage here only checked that the stored
+/// pin_hash was non-empty.
+#[tokio::test]
+#[ignore]
+async fn test_migration_history_records_the_expected_pin_hash() -> Result<()> {
+    require_postgres()?;
+
+    let helper =
+        IntegrationTestHelper::new("test_migration_history_records_the_expected_pin_hash", None)
+            .await?;
+
+    // --no-pin case: pin_hash should equal an independently-computed hash of
+    // the current (unpinned) component tree. Nothing here checks for a
+    // lasting side effect, so a plain SELECT is enough.
+    let unpinned_content = "BEGIN;\n\nSELECT true;\n\nCOMMIT;";
+    let unpinned_name = helper
+        .migration_helper
+        .create_migration_manual("pin-hash-unpinned", unpinned_content.to_string())
+        .await?;
+    helper.apply_migration(&unpinned_name).await?;
+
+    let config = helper.migration_helper.load_config().await?;
+    let expected_unpinned_pin_hash = Migrator::new(&config, &unpinned_name, false)
+        .pin_hash()
+        .await?;
+
+    let unpinned_pin_hash = helper.execute_sql(&format!(
+        "SELECT mh.pin_hash FROM _spawn.migration m \
+         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
+         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
+        unpinned_name
+    ))?;
+    assert!(
+        unpinned_pin_hash.contains(&expected_unpinned_pin_hash),
+        "expected pin_hash '{}' for --no-pin apply, got: {}",
+        expected_unpinned_pin_hash,
+        unpinned_pin_hash
+    );
+
+    // Pinned case: pin_hash should equal the hash recorded in lock.toml.
+    let pinned_content = "BEGIN;\n\nSELECT true;\n\nCOMMIT;";
+    let pinned_name = helper
+        .migration_helper
+        .create_migration_manual("pin-hash-pinned", pinned_content.to_string())
+        .await?;
+    let pin_hash = helper.migration_helper.pin_migration(&pinned_name).await?;
+
+    let cmd = ApplyMigration {
+        migration: Some(pinned_name.clone()),
+        pinned: true,
+        variables: None,
+        yes: true,
+        retry: false,
+        reuse_connection: false,
+    };
+    let config = helper.migration_helper.load_config().await?;
+    cmd.execute(&config).await?;
+
+    let pinned_pin_hash = helper.execute_sql(&format!(
+        "SELECT mh.pin_hash FROM _spawn.migration m \
+         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
+         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
+        pinned_name
+    ))?;
+    assert!(
+        pinned_pin_hash.contains(&pin_hash),
+        "expected pin_hash '{}' for pinned apply, got: {}",
+        pin_hash,
+        pinned_pin_hash
     );
 
     Ok(())

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -42,7 +42,7 @@ use opendal::services::Memory;
 use opendal::Operator;
 use spawn_db::{
     commands::{AdoptMigration, ApplyMigration, Command, CompareTests, ExpectTest, Outcome},
-    config::ConfigLoaderSaver,
+    config::{Config, ConfigLoaderSaver},
     engine::{CommandSpec, EngineType, TargetConfig},
     migrator::Migrator,
     secrets::{SecretDefinition, SecretSource, SecretsRenderMode},
@@ -1476,19 +1476,21 @@ async fn test_apply_error_redacts_resolved_secret_values() -> Result<()> {
     Ok(())
 }
 
-/// migration_history.checksum must fingerprint the raw, unrendered up.sql —
-/// never the rendered SQL, which would embed resolved secret values (see
-/// StreamingGeneration::raw_checksum's doc comment, and the template.rs unit
-/// tests for the pure-function version of this property). This exercises
-/// the real `apply` pipeline end to end.
+/// migration_history.checksum and .pin_hash must reflect the raw, unrendered
+/// up.sql and the actual component tree used — never the rendered SQL
+/// (which could embed secret values) and never a stale/non-empty value.
+/// The previous coverage here only checked that both columns were
+/// non-empty. One migration is retried through a sequence of edits to cover
+/// all four properties cheaply: secret rotation and pinning must each leave
+/// their respective column unchanged, while editing up.sql and pinning
+/// history must each move it.
 #[tokio::test]
 #[ignore]
-async fn test_migration_history_checksum_is_raw_source_and_secret_rotation_invariant() -> Result<()>
-{
+async fn test_migration_history_records_expected_checksum_and_pin_hash() -> Result<()> {
     require_postgres()?;
 
     let helper = IntegrationTestHelper::new(
-        "test_migration_history_checksum_is_raw_source_and_secret_rotation_invariant",
+        "test_migration_history_records_expected_checksum_and_pin_hash",
         None,
     )
     .await?;
@@ -1510,7 +1512,6 @@ async fn test_migration_history_checksum_is_raw_source_and_secret_rotation_invar
         config_loader.secrets = Some(secrets);
         config_loader
     };
-
     save_secret("hunter2")
         .save(
             helper.migration_helper.config_path(),
@@ -1518,166 +1519,107 @@ async fn test_migration_history_checksum_is_raw_source_and_secret_rotation_invar
         )
         .await?;
 
-    // A plain SELECT has no side effects, so re-applying it via --retry
-    // below is trivially safe to repeat.
-    let migration_content =
-        "BEGIN;\n\nSELECT {{ secret(\"application_password\") }}::text;\n\nCOMMIT;";
+    // A plain SELECT has no side effects, so retrying it below is trivially
+    // safe to repeat.
     let migration_name = helper
         .migration_helper
-        .create_migration_manual("checksum-rotation", migration_content.to_string())
+        .create_migration_manual(
+            "checksum-and-pin-hash",
+            "BEGIN;\n\nSELECT {{ secret(\"application_password\") }}::text;\n\nCOMMIT;"
+                .to_string(),
+        )
         .await?;
 
-    helper.apply_migration(&migration_name).await?;
-
-    // Computed via the same production code path `apply` uses, independent
-    // of the round trip through the database.
-    let config = helper.migration_helper.load_config().await?;
-    let expected_checksum = Migrator::new(&config, &migration_name, false)
-        .generate_streaming(None, SecretsRenderMode::Masked)
-        .await?
-        .raw_checksum();
-
-    let checksum_query = format!(
-        "SELECT encode(mh.checksum, 'hex') FROM _spawn.migration m \
+    let row_query = format!(
+        "SELECT encode(mh.checksum, 'hex'), mh.pin_hash FROM _spawn.migration m \
          JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
          WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
         migration_name
     );
-    let history_count_query = format!(
+    let count_query = format!(
         "SELECT COUNT(*) FROM _spawn.migration m \
          JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
          WHERE m.name = '{}';",
         migration_name
     );
+    // Asserts against the latest history row, and that `count` rows exist —
+    // the latter proves each retry actually recorded a new row rather than
+    // this just re-reading a previous one.
+    let assert_latest_row = |count: &str, checksum: &str, pin_hash: &str| -> Result<()> {
+        let got_count = helper.execute_sql(&count_query)?;
+        assert!(
+            got_count.contains(count),
+            "expected {} history row(s), got: {}",
+            count,
+            got_count
+        );
+        let row = helper.execute_sql(&row_query)?;
+        assert!(
+            row.contains(checksum) && row.contains(pin_hash),
+            "expected checksum '{}' and pin_hash '{}' in latest row, got: {}",
+            checksum,
+            pin_hash,
+            row
+        );
+        Ok(())
+    };
+    async fn retry_apply(config: &Config, migration_name: &str, pinned: bool) -> Result<()> {
+        ApplyMigration {
+            migration: Some(migration_name.to_string()),
+            pinned,
+            variables: None,
+            yes: true,
+            retry: true,
+            reuse_connection: false,
+        }
+        .execute(config)
+        .await?;
+        Ok(())
+    }
 
-    let first_checksum = helper.execute_sql(&checksum_query)?;
-    assert!(
-        first_checksum.contains(&expected_checksum),
-        "expected checksum '{}' in result, got: {}",
-        expected_checksum,
-        first_checksum
-    );
-    let history_count_after_first = helper.execute_sql(&history_count_query)?;
-    assert!(
-        history_count_after_first.contains("1"),
-        "expected exactly 1 history row after the first apply, got: {}",
-        history_count_after_first
-    );
+    helper.apply_migration(&migration_name).await?;
+    let config = helper.migration_helper.load_config().await?;
+    let mgrtr = Migrator::new(&config, &migration_name, false);
+    let checksum = mgrtr
+        .generate_streaming(None, SecretsRenderMode::Masked)
+        .await?
+        .raw_checksum();
+    let pin_hash = mgrtr.pin_hash().await?;
+    assert_latest_row("1", &checksum, &pin_hash)?;
 
-    // Rotate the secret's value and re-apply the same up.sql — the checksum
-    // must not move.
+    // Rotating the secret and re-applying must leave both columns unchanged.
     save_secret("a-totally-different-value")
         .save(
             helper.migration_helper.config_path(),
             &helper.migration_helper.fs,
         )
         .await?;
-
     let config = helper.migration_helper.load_config().await?;
-    let cmd = ApplyMigration {
-        migration: Some(migration_name.clone()),
-        pinned: false,
-        variables: None,
-        yes: true,
-        retry: true,
-        reuse_connection: false,
-    };
-    cmd.execute(&config).await?;
+    retry_apply(&config, &migration_name, false).await?;
+    assert_latest_row("2", &checksum, &pin_hash)?;
 
-    // Prove the retry actually recorded a second row rather than the
-    // checksum query below just re-reading the first one — otherwise this
-    // test would pass even if --retry silently no-op'd.
-    let history_count_after_retry = helper.execute_sql(&history_count_query)?;
-    assert!(
-        history_count_after_retry.contains("2"),
-        "expected exactly 2 history rows after the --retry apply, got: {}",
-        history_count_after_retry
-    );
-
-    let second_checksum = helper.execute_sql(&checksum_query)?;
-    assert!(
-        second_checksum.contains(&expected_checksum),
-        "checksum changed after rotating the secret's value, expected '{}' in: {}",
-        expected_checksum,
-        second_checksum
-    );
-
-    Ok(())
-}
-
-/// migration_history.pin_hash must record the actual component-tree hash
-/// used to render the migration — the real pinned hash from lock.toml when
-/// pinned, or the equivalent hash of the current tree when applied with
-/// --no-pin. The previous test coverage here only checked that the stored
-/// pin_hash was non-empty.
-#[tokio::test]
-#[ignore]
-async fn test_migration_history_records_the_expected_pin_hash() -> Result<()> {
-    require_postgres()?;
-
-    let helper =
-        IntegrationTestHelper::new("test_migration_history_records_the_expected_pin_hash", None)
-            .await?;
-
-    // --no-pin case: pin_hash should equal an independently-computed hash of
-    // the current (unpinned) component tree. Nothing here checks for a
-    // lasting side effect, so a plain SELECT is enough.
-    let unpinned_content = "BEGIN;\n\nSELECT true;\n\nCOMMIT;";
-    let unpinned_name = helper
+    // Editing up.sql itself (secret unchanged) must change the checksum,
+    // but not the pin_hash (no components are involved either way).
+    helper
         .migration_helper
-        .create_migration_manual("pin-hash-unpinned", unpinned_content.to_string())
+        .fs
+        .write(
+            &config.pather().migration_script_file_path(&migration_name),
+            "BEGIN;\n\nSELECT {{ secret(\"application_password\") }}::text; -- edited\n\nCOMMIT;",
+        )
         .await?;
-    helper.apply_migration(&unpinned_name).await?;
+    let checksum = Migrator::new(&config, &migration_name, false)
+        .generate_streaming(None, SecretsRenderMode::Masked)
+        .await?
+        .raw_checksum();
+    retry_apply(&config, &migration_name, false).await?;
+    assert_latest_row("3", &checksum, &pin_hash)?;
 
-    let config = helper.migration_helper.load_config().await?;
-    let expected_unpinned_pin_hash = Migrator::new(&config, &unpinned_name, false)
-        .pin_hash()
-        .await?;
-
-    let unpinned_pin_hash = helper.execute_sql(&format!(
-        "SELECT mh.pin_hash FROM _spawn.migration m \
-         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
-         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
-        unpinned_name
-    ))?;
-    assert!(
-        unpinned_pin_hash.contains(&expected_unpinned_pin_hash),
-        "expected pin_hash '{}' for --no-pin apply, got: {}",
-        expected_unpinned_pin_hash,
-        unpinned_pin_hash
-    );
-
-    // Pinned case: pin_hash should equal the hash recorded in lock.toml.
-    let pinned_content = "BEGIN;\n\nSELECT true;\n\nCOMMIT;";
-    let pinned_name = helper
-        .migration_helper
-        .create_migration_manual("pin-hash-pinned", pinned_content.to_string())
-        .await?;
-    let pin_hash = helper.migration_helper.pin_migration(&pinned_name).await?;
-
-    let cmd = ApplyMigration {
-        migration: Some(pinned_name.clone()),
-        pinned: true,
-        variables: None,
-        yes: true,
-        retry: false,
-        reuse_connection: false,
-    };
-    let config = helper.migration_helper.load_config().await?;
-    cmd.execute(&config).await?;
-
-    let pinned_pin_hash = helper.execute_sql(&format!(
-        "SELECT mh.pin_hash FROM _spawn.migration m \
-         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
-         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
-        pinned_name
-    ))?;
-    assert!(
-        pinned_pin_hash.contains(&pin_hash),
-        "expected pin_hash '{}' for pinned apply, got: {}",
-        pin_hash,
-        pinned_pin_hash
-    );
+    // Pinning and re-applying pinned must change the pin_hash to the real
+    // lock.toml value, without touching the checksum (up.sql is unchanged).
+    let pin_hash = helper.migration_helper.pin_migration(&migration_name).await?;
+    retry_apply(&config, &migration_name, true).await?;
+    assert_latest_row("4", &checksum, &pin_hash)?;
 
     Ok(())
 }

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -241,6 +241,7 @@ impl IntegrationTestHelper {
             test_template: None,
             up_template: None,
             targets: Some(targets),
+            secrets: None,
             project_id: None,
             telemetry: Some(false),
         }
@@ -1650,6 +1651,7 @@ async fn test_spawn_database_config() -> Result<()> {
         test_template: None,
         up_template: None,
         targets: Some(targets),
+        secrets: None,
         project_id: None,
         telemetry: Some(false),
     };

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -1333,6 +1333,82 @@ COMMIT;"#;
     Ok(())
 }
 
+/// A writer failure (e.g. an undefined `secret()` call) is a different
+/// failure path than a nonzero psql exit, and must still record a FAILURE
+/// row rather than abandoning the migration with no history.
+#[tokio::test]
+#[ignore]
+async fn test_migration_writer_failure_still_records_history() -> Result<()> {
+    require_postgres()?;
+
+    let helper =
+        IntegrationTestHelper::new("test_migration_writer_failure_still_records_history", None)
+            .await?;
+
+    // CREATE TABLE autocommits before the engine reaches the failing
+    // secret() call, proving streamed SQL persists past a writer failure.
+    let bad_migration = r#"CREATE TABLE writer_failure_check (id integer);
+
+BEGIN;
+
+SELECT {{ secret("does_not_exist") }};
+
+COMMIT;"#;
+
+    let migration_name = helper
+        .migration_helper
+        .create_migration_manual("writer-failure", bad_migration.to_string())
+        .await?;
+
+    let result = helper.apply_migration(&migration_name).await;
+    assert!(
+        result.is_err(),
+        "Expected migration with an undefined secret() call to fail"
+    );
+
+    assert!(
+        helper.table_exists("public", "writer_failure_check")?,
+        "SQL streamed before the writer failure should already have executed against the database"
+    );
+
+    let status_check = helper.execute_sql(&format!(
+        "SELECT mh.status_id_status FROM _spawn.migration m \
+         JOIN _spawn.migration_history mh ON m.migration_id = mh.migration_id_migration \
+         WHERE m.name = '{}' ORDER BY mh.created_at DESC LIMIT 1;",
+        migration_name
+    ))?;
+    assert!(
+        status_check.contains("FAILURE"),
+        "Migration should be recorded with FAILURE status even though psql itself never \
+         reported a nonzero exit, got: {}",
+        status_check
+    );
+
+    // Confirms the FAILURE row is actually persisted, not just transient.
+    let config = helper.migration_helper.load_config().await?;
+    let cmd = ApplyMigration {
+        migration: Some(migration_name.clone()),
+        pinned: false,
+        variables: None,
+        yes: true,
+        retry: false,
+        reuse_connection: false,
+    };
+    let result = cmd.execute(&config).await;
+    assert!(
+        result.is_err(),
+        "apply without --retry should fail after a previous writer-failure attempt"
+    );
+    let err_msg = result.err().unwrap().to_string();
+    assert!(
+        err_msg.contains("previous") && err_msg.contains("FAILURE"),
+        "error should mention previous FAILURE attempt, got: {}",
+        err_msg
+    );
+
+    Ok(())
+}
+
 /// A failed apply must never leak a resolved secret value into the returned
 /// error, even when Postgres itself echoes the offending literal back (as
 /// it does for e.g. "invalid input syntax" errors).

--- a/tests/integration_postgres.rs
+++ b/tests/integration_postgres.rs
@@ -44,6 +44,7 @@ use spawn_db::{
     commands::{AdoptMigration, ApplyMigration, Command, CompareTests, ExpectTest, Outcome},
     config::ConfigLoaderSaver,
     engine::{CommandSpec, EngineType, TargetConfig},
+    secrets::{SecretDefinition, SecretSource},
 };
 use std::collections::HashMap;
 use std::env;
@@ -1327,6 +1328,71 @@ COMMIT;"#;
         !err_msg.contains("previous"),
         "with --retry the error should be from the migration SQL, not PreviousAttemptFailed, got: {}",
         err_msg
+    );
+
+    Ok(())
+}
+
+/// A failed apply must never leak a resolved secret value into the returned
+/// error, even when Postgres itself echoes the offending literal back (as
+/// it does for e.g. "invalid input syntax" errors).
+#[tokio::test]
+#[ignore]
+async fn test_apply_error_redacts_resolved_secret_values() -> Result<()> {
+    require_postgres()?;
+
+    let helper =
+        IntegrationTestHelper::new("test_apply_error_redacts_resolved_secret_values", None)
+            .await?;
+
+    let secret_value = "hunter2-distinctive-secret-value";
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "application_password".to_string(),
+        SecretDefinition {
+            default: SecretSource::Literal {
+                value: secret_value.to_string(),
+                insecure: true,
+            },
+            environments: HashMap::new(),
+        },
+    );
+    let mut config_loader =
+        IntegrationTestHelper::create_config(&helper.db_name, &helper.connection_mode);
+    config_loader.secrets = Some(secrets);
+    config_loader
+        .save(helper.migration_helper.config_path(), &helper.migration_helper.fs)
+        .await?;
+
+    // Casting the secret to an integer guarantees Postgres echoes the exact
+    // literal back in its own error message ("invalid input syntax for type
+    // integer: \"...\""), independent of any table/constraint setup.
+    let bad_migration = format!(
+        "BEGIN;\n\nSELECT {{{{ secret(\"application_password\") }}}}::integer;\n\nCOMMIT;"
+    );
+    let migration_name = helper
+        .migration_helper
+        .create_migration_manual("secret-then-fail", bad_migration)
+        .await?;
+
+    let result = helper.apply_migration(&migration_name).await;
+    let err = result.expect_err("expected migration to fail on the bad cast");
+    let full_text = format!("{:?}", err);
+
+    assert!(
+        !full_text.contains(secret_value),
+        "secret value leaked into apply error: {}",
+        full_text
+    );
+    assert!(
+        full_text.contains("***REDACTED***"),
+        "expected a redaction marker in the error, got: {}",
+        full_text
+    );
+    assert!(
+        full_text.contains("invalid input syntax"),
+        "redaction should not have destroyed the rest of the error's useful detail, got: {}",
+        full_text
     );
 
     Ok(())

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -471,6 +471,43 @@ COMMIT;"#
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_build_with_pinned_fails_if_pinned_file_tampered_with(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let helper =
+        MigrationTestHelper::new_from_local_folder("./static/tests/build_with_component").await?;
+
+    let migration_name = "20240907212659-initial";
+    helper.pin_migration(migration_name).await?;
+
+    // Corrupt the pinned blob directly on disk (bypassing pin/build), the
+    // same way a stray edit to a file under pinned/ would. Its path is
+    // content-addressed by the *original* content's hash, so this simulates
+    // the path and the bytes at that path disagreeing.
+    let original_component = helper
+        .fs
+        .read("/db/components/util/add_func.sql")
+        .await?
+        .to_bytes();
+    let hash = store::pinner::pin_contents(&helper.fs, None, &original_component).await?;
+    let pinned_path = format!("/db/pinned/{}", store::pinner::hash_to_path(&hash)?);
+    helper
+        .fs
+        .write(&pinned_path, "-- tampered contents".to_string())
+        .await?;
+
+    let result = helper.build_migration(migration_name, true).await;
+    let err = result.expect_err("build with a tampered pinned file should fail");
+    let err_msg = format!("{:?}", err);
+    assert!(
+        err_msg.contains("does not match its expected hash"),
+        "expected a hash-mismatch error, got: {}",
+        err_msg
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_migration_build_with_variables() -> Result<(), Box<dyn std::error::Error>> {
     let helper =
         MigrationTestHelper::new_from_local_folder("./static/tests/build_with_variables").await?;

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -10,6 +10,7 @@ use spawn_db::{
     },
     config::{Config, ConfigLoaderSaver},
     engine::{CommandSpec, EngineType, TargetConfig},
+    secrets::{SecretDefinition, SecretSource},
     store,
 };
 use std::collections::HashMap;
@@ -107,6 +108,7 @@ impl MigrationTestHelper {
             up_template: None,
             test_template: None,
             targets: Some(targets),
+            secrets: None,
             project_id: None,
             telemetry: Some(false),
         }
@@ -189,6 +191,7 @@ impl MigrationTestHelper {
             migration: migration_name.to_string(),
             pinned,
             variables,
+            reveal_secrets: false,
         };
 
         let outcome = cmd.execute(&config).await?;
@@ -691,6 +694,7 @@ COMMIT;"#;
         migration: migration_name.to_string(),
         pinned: false,
         variables: None,
+        reveal_secrets: false,
     };
 
     let outcome = cmd.execute(&config).await?;
@@ -701,6 +705,7 @@ COMMIT;"#;
         migration: migration_name.to_string(),
         pinned: true,
         variables: None,
+        reveal_secrets: false,
     };
 
     let outcome_pinned = cmd_pinned.execute(&config).await?;
@@ -801,6 +806,103 @@ async fn test_pin_cleanup_finds_and_deletes_orphans() -> Result<(), Box<dyn std:
         files_after_cleanup.len(),
         "cleanup should delete 4 orphaned pinned files"
     );
+
+    Ok(())
+}
+
+/// Exercises the full stack for secrets: a [secrets.*] table round-tripped
+/// through real TOML (via ConfigLoaderSaver::save/Config::load), an
+/// environment-specific override, and both masked and revealed builds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_migration_build_with_secrets() -> Result<(), Box<dyn std::error::Error>> {
+    let mut targets = HashMap::new();
+    targets.insert(
+        "postgres_psql".to_string(),
+        TargetConfig {
+            engine: EngineType::PostgresPSQL,
+            spawn_database: Some("spawn".to_string()),
+            spawn_schema: "public".to_string(),
+            environment: "dev".to_string(),
+            command: None,
+        },
+    );
+
+    let mut secrets = HashMap::new();
+    secrets.insert(
+        "application_password".to_string(),
+        SecretDefinition {
+            default: SecretSource::Literal {
+                value: "prod-secret".to_string(),
+                insecure: true,
+            },
+            environments: HashMap::from([(
+                "dev".to_string(),
+                SecretSource::Literal {
+                    value: "dev-secret".to_string(),
+                    insecure: true,
+                },
+            )]),
+        },
+    );
+
+    let config_loader = ConfigLoaderSaver {
+        spawn_folder: "/db".to_string(),
+        target: Some("postgres_psql".to_string()),
+        environment: Some("dev".to_string()),
+        up_template: None,
+        test_template: None,
+        targets: Some(targets),
+        secrets: Some(secrets),
+        project_id: None,
+        telemetry: Some(false),
+    };
+
+    let mem_op = Operator::new(Memory::default())?;
+    let helper = MigrationTestHelper::new_from_operator_with_config(mem_op, config_loader).await?;
+
+    let migration_name = helper
+        .create_migration_manual(
+            "with-secret",
+            "SELECT {{ secret(\"application_password\") }};".to_string(),
+        )
+        .await?;
+
+    let config = helper.load_config().await?;
+
+    // Masked build (default): must not leak either the default or the
+    // environment-specific value.
+    let masked_outcome = BuildMigration {
+        migration: migration_name.clone(),
+        pinned: false,
+        variables: None,
+        reveal_secrets: false,
+    }
+    .execute(&config)
+    .await?;
+    let masked_content = match masked_outcome {
+        Outcome::BuiltMigration { content, .. } => content,
+        _ => panic!("unexpected outcome"),
+    };
+    assert!(masked_content.contains("***MASKED:application_password***"));
+    assert!(!masked_content.contains("dev-secret"));
+    assert!(!masked_content.contains("prod-secret"));
+
+    // Revealed build: current environment is "dev", so the override wins
+    // over the default.
+    let revealed_outcome = BuildMigration {
+        migration: migration_name,
+        pinned: false,
+        variables: None,
+        reveal_secrets: true,
+    }
+    .execute(&config)
+    .await?;
+    let revealed_content = match revealed_outcome {
+        Outcome::BuiltMigration { content, .. } => content,
+        _ => panic!("unexpected outcome"),
+    };
+    assert!(revealed_content.contains("dev-secret"));
+    assert!(!revealed_content.contains("prod-secret"));
 
     Ok(())
 }


### PR DESCRIPTION
Implementation that allows us to handle secrets in a secure way, along with having different secrets for local/dev vs production.

Changes checksum calculation to be based on the hash of `up.sql` only, so we now store that hash combined with the pin (where pin is calculated to what it would be if running with `--no-pin`).  This is because the old hash would be calculated using a fast hashing method across the entire output INCLUDING secrets, which could lead to dictionary attacks to try and deduce the secret from the known output plus hash.

Also fixes a bug with environment.

Copilot has done good work detecting a bunch of security issues related to this change, and so tests and fixes have been applied in this PR too.