### PR TITLE
implement pin verify

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -71,7 +71,10 @@ export default defineConfig({
             { label: "spawn check", slug: "cli/check" },
             {
               label: "Pin",
-              items: [{ label: "spawn pin cleanup", slug: "cli/pin-cleanup" }],
+              items: [
+                { label: "spawn pin cleanup", slug: "cli/pin-cleanup" },
+                { label: "spawn pin verify", slug: "cli/pin-verify" },
+              ],
             },
             {
               label: "Migration",

--- a/docs/src/content/docs/cli/pin-verify.mdx
+++ b/docs/src/content/docs/cli/pin-verify.mdx
@@ -1,0 +1,72 @@
+---
+title: spawn pin verify
+description: Verify the integrity of the pinned store.
+---
+
+import CLICommand from "../../../components/CLICommand.astro";
+import { globalOptions, targetOption } from "../../../components/cli-options";
+
+<CLICommand
+  usage="spawn pin verify"
+  options={[...targetOption, ...globalOptions]}
+>
+
+## Overview
+
+The pinned store in `pinned/` is content-addressed: each file is stored at a path derived from a hash of its own contents, and each migration's `lock.toml` records the root hash of the tree it was pinned against. Both of these can, in principle, get out of sync with reality — a stray edit, a bad merge, or manual tampering with `pinned/` can leave a file's contents disagreeing with its path, or a migration pointing at a root hash that no longer exists.
+
+The `verify` command checks both invariants without modifying anything.
+
+## Behavior
+
+1. Walks every file in the `pinned/` directory and recomputes its content hash, comparing it against the hash encoded in its path
+2. Reads every migration's `lock.toml` and checks that its root hash has a corresponding file in `pinned/`
+
+## Examples
+
+### A healthy store
+
+```bash
+spawn pin verify
+```
+
+Output:
+
+```
+Checked 12 pinned file(s): all match their content hash.
+All migration lock files point to a root hash that exists in the store.
+```
+
+### A tampered file
+
+```bash
+spawn pin verify
+```
+
+Output:
+
+```
+Checked 12 pinned file(s): 1 corrupted.
+  pinned/7a/3f5e8b9c2d1a4e6f8b0c2d4e6f8a0b — expected hash '7a3f5e8b9c2d1a4e6f8b0c2d4e6f8a0b', got '93b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8'
+All migration lock files point to a root hash that exists in the store.
+```
+
+### A missing root
+
+```bash
+spawn pin verify
+```
+
+Output:
+
+```
+Checked 12 pinned file(s): all match their content hash.
+1 migration(s) point to a missing root hash:
+  20240907212659-initial — missing root hash '00000000000000000000000000000000'
+```
+
+## Exit status
+
+`spawn pin verify` exits with a non-zero status if any corrupted file or missing root hash is found, so it can be used as a CI check.
+
+</CLICommand>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::commands::{
     AdoptMigration, ApplyMigration, BuildMigration, BuildTest, Check, Command, CompareTests,
     ExpectTest, Init, MigrationStatus, NewMigration, NewTest, Outcome, PinCleanup, PinMigration,
-    RunTest, TelemetryDescribe, TelemetryInfo,
+    PinVerify, RunTest, TelemetryDescribe, TelemetryInfo,
 };
 use crate::completions::{complete_migrations, complete_tests};
 use crate::config::{Config, DEFAULT_CONFIG_FILE};
@@ -225,6 +225,10 @@ pub enum PinCommands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Verify the integrity of the pinned store: that every pinned file still
+    /// matches its content hash, and that every migration's lock.toml points
+    /// to a root hash that exists in the store.
+    Verify,
 }
 
 impl TelemetryDescribe for PinCommands {
@@ -232,6 +236,7 @@ impl TelemetryDescribe for PinCommands {
         match self {
             PinCommands::Cleanup { dry_run } => TelemetryInfo::new("cleanup")
                 .with_properties(vec![("dry_run", dry_run.to_string())]),
+            PinCommands::Verify => TelemetryInfo::new("verify"),
         }
     }
 }
@@ -364,6 +369,7 @@ async fn run_command(cli: Cli, config: &mut Config) -> Result<Outcome> {
         Some(Commands::Check) => Check.execute(config).await,
         Some(Commands::Pin { command }) => match command {
             Some(PinCommands::Cleanup { dry_run }) => PinCleanup { dry_run }.execute(config).await,
+            Some(PinCommands::Verify) => PinVerify.execute(config).await,
             None => {
                 eprintln!("No pin subcommand specified");
                 Ok(Outcome::Unimplemented)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod check;
 pub mod init;
 pub mod migration;
 pub mod pin_cleanup;
+pub mod pin_verify;
 pub mod test;
 
 pub use check::Check;
@@ -14,6 +15,7 @@ pub use migration::{
     PinMigration,
 };
 pub use pin_cleanup::PinCleanup;
+pub use pin_verify::PinVerify;
 pub use test::{BuildTest, CompareTests, ExpectTest, NewTest, RunTest};
 
 /// Telemetry information for a command.
@@ -70,6 +72,12 @@ pub enum Outcome {
         referenced_count: usize,
         /// Whether this was a dry run.
         dry_run: bool,
+    },
+    PinVerify {
+        /// Number of pinned files whose contents no longer match their hash.
+        corrupted_count: usize,
+        /// Number of migrations whose lock.toml root hash is missing from the store.
+        missing_root_count: usize,
     },
     NewMigration(String),
     NewTest(String),

--- a/src/commands/pin_verify.rs
+++ b/src/commands/pin_verify.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+
+use crate::commands::{Command, Outcome, TelemetryDescribe, TelemetryInfo};
+use crate::config::Config;
+use crate::store::pinner::spawn::verify_store;
+
+pub struct PinVerify;
+
+impl TelemetryDescribe for PinVerify {
+    fn telemetry(&self) -> TelemetryInfo {
+        TelemetryInfo::new("verify")
+    }
+}
+
+impl Command for PinVerify {
+    async fn execute(&self, config: &Config) -> Result<Outcome> {
+        let pather = config.pather();
+        let fs = config.operator();
+
+        let result = verify_store(fs, &pather).await?;
+
+        if result.corrupted.is_empty() {
+            println!(
+                "Checked {} pinned file(s): all match their content hash.",
+                result.checked_count
+            );
+        } else {
+            println!(
+                "Checked {} pinned file(s): {} corrupted.",
+                result.checked_count,
+                result.corrupted.len()
+            );
+            for file in &result.corrupted {
+                println!(
+                    "  {} — expected hash '{}', got '{}'",
+                    file.path, file.expected_hash, file.actual_hash
+                );
+            }
+        }
+
+        if result.missing_roots.is_empty() {
+            println!("All migration lock files point to a root hash that exists in the store.");
+        } else {
+            println!(
+                "{} migration(s) point to a missing root hash:",
+                result.missing_roots.len()
+            );
+            for missing in &result.missing_roots {
+                println!(
+                    "  {} — missing root hash '{}'",
+                    missing.migration, missing.hash
+                );
+            }
+        }
+
+        let corrupted_count = result.corrupted.len();
+        let missing_root_count = result.missing_roots.len();
+
+        Ok(Outcome::PinVerify {
+            corrupted_count,
+            missing_root_count,
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,11 +255,7 @@ impl Config {
     }
 
     pub async fn load_lock_file(&self, lock_file_path: &str) -> Result<LockData> {
-        let contents = self.operator().read(lock_file_path).await?.to_bytes();
-        let contents = String::from_utf8(contents.to_vec())?;
-        let lock_data: LockData = toml::from_str(&contents)?;
-
-        Ok(lock_data)
+        crate::pinfile::load_lock_file(self.operator(), lock_file_path).await
     }
 
     /// Load variables from a file path.

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,34 @@
+//! Central place for the content-hashing scheme shared by pinning, lock
+//! files, and migration checksums, so every call site hashes and formats
+//! consistently.
+
+use twox_hash::xxhash3_128;
+
+/// Hashes `contents` and returns it as a fixed-width lowercase hex string.
+pub fn content_hash(contents: &[u8]) -> String {
+    format!("{:032x}", xxhash3_128::Hasher::oneshot(contents))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_a_32_character_lowercase_hex_string() {
+        let hash = content_hash(b"hello world");
+        assert_eq!(hash.len(), 32);
+        assert!(hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    #[test]
+    fn is_deterministic() {
+        assert_eq!(content_hash(b"same input"), content_hash(b"same input"));
+    }
+
+    #[test]
+    fn differs_for_different_input() {
+        assert_ne!(content_hash(b"a"), content_hash(b"b"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod completions;
 pub mod config;
 pub mod engine;
 pub mod escape;
+pub mod hash;
 pub mod migrator;
 pub mod pinfile;
 pub mod secrets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,15 @@ async fn async_main(cli: Cli) -> Result<()> {
         Outcome::PinCleanup { .. } => {
             // Output is handled by the command itself
         }
+        Outcome::PinVerify {
+            corrupted_count,
+            missing_root_count,
+        } => {
+            // Output is handled by the command itself
+            if corrupted_count > 0 || missing_root_count > 0 {
+                std::process::exit(1);
+            }
+        }
         Outcome::Success => {}
         Outcome::Unimplemented => {
             println!("Unimplemented command.");

--- a/src/pinfile.rs
+++ b/src/pinfile.rs
@@ -1,3 +1,5 @@
+use anyhow::{Context, Result};
+use opendal::Operator;
 use serde::{Deserialize, Serialize};
 
 // The overall config, containing a map from filename → FileEntry.
@@ -6,4 +8,18 @@ pub struct LockData {
     // Reference to the pinned files.  Might be an xxhash for spawn's pinning
     // system, or a specific git root object hash, etc.
     pub pin: String,
+}
+
+/// Reads and parses a lock.toml at `path`. The canonical way to load a
+/// migration's lock file — callers that need to attribute a failure to a
+/// specific migration should wrap this with their own `.with_context(...)`.
+pub async fn load_lock_file(fs: &Operator, path: &str) -> Result<LockData> {
+    let contents = fs
+        .read(path)
+        .await
+        .with_context(|| format!("failed to read lock file '{}'", path))?
+        .to_bytes();
+    let contents = String::from_utf8(contents.to_vec())
+        .with_context(|| format!("lock file '{}' is not valid UTF-8", path))?;
+    toml::from_str(&contents).with_context(|| format!("failed to parse lock file '{}'", path))
 }

--- a/src/store/pinner/gc.rs
+++ b/src/store/pinner/gc.rs
@@ -3,12 +3,11 @@
 //! Finds and removes pinned files that are no longer referenced by any migration's lock.toml.
 
 use anyhow::{Context, Result};
-use futures::TryStreamExt;
 use opendal::Operator;
 use std::collections::HashSet;
 
 use crate::config::FolderPather;
-use crate::pinfile::LockData;
+use crate::pinfile;
 use crate::store::list_migration_fs_status;
 
 use super::{hash_to_path, read_hash_file, EntryKind, Tree};
@@ -72,14 +71,9 @@ async fn collect_referenced_hashes(
 
         // Load lock.toml
         let lock_path = pather.migration_lock_file_path(&name);
-        let contents = fs
-            .read(&lock_path)
+        let lock_data = pinfile::load_lock_file(fs, &lock_path)
             .await
-            .with_context(|| format!("failed to read lock file for migration {}", name))?
-            .to_bytes();
-        let contents = String::from_utf8(contents.to_vec())?;
-        let lock_data: LockData = toml::from_str(&contents)
-            .with_context(|| format!("failed to parse lock file for migration {}", name))?;
+            .with_context(|| format!("failed to load lock file for migration {}", name))?;
 
         // Walk tree and collect all hashes
         walk_tree_hashes(fs, &pather.pinned_folder(), &lock_data.pin, &mut referenced)
@@ -92,37 +86,11 @@ async fn collect_referenced_hashes(
 
 /// List all files in the pinned folder and return their hashes.
 async fn list_pinned_hashes(fs: &Operator, pinned_folder: &str) -> Result<HashSet<String>> {
-    let mut hashes = HashSet::new();
-
-    let prefix = format!("{}/", pinned_folder.trim_end_matches('/'));
-    let mut lister = fs
-        .lister_with(&prefix)
-        .recursive(true)
-        .await
-        .context("failed to list pinned folder")?;
-
-    while let Some(entry) = lister.try_next().await? {
-        // Skip directories
-        if entry.path().ends_with('/') {
-            continue;
-        }
-
-        // The path structure is: <pinned_folder>/<XX>/<rest_of_hash>
-        // We want to extract just the hash: XX + rest_of_hash
-        // Split by '/' and take the last two components
-        let path = entry.path();
-        let components: Vec<&str> = path.split('/').collect();
-        if components.len() >= 2 {
-            let prefix_part = components[components.len() - 2];
-            let rest_part = components[components.len() - 1];
-            let hash = format!("{}{}", prefix_part, rest_part);
-            if !hash.is_empty() {
-                hashes.insert(hash);
-            }
-        }
-    }
-
-    Ok(hashes)
+    Ok(super::list_store_files(fs, pinned_folder)
+        .await?
+        .into_iter()
+        .map(|file| file.hash())
+        .collect())
 }
 
 /// Run garbage collection on the pinned folder.

--- a/src/store/pinner/mod.rs
+++ b/src/store/pinner/mod.rs
@@ -6,7 +6,8 @@ use opendal::Operator;
 use serde::{Deserialize, Serialize};
 
 use std::fmt::Debug;
-use twox_hash::xxhash3_128;
+
+use crate::hash::content_hash;
 
 pub mod gc;
 pub mod latest;
@@ -52,8 +53,7 @@ pub async fn pin_contents(
     store_path: Option<&str>,
     contents: &[u8],
 ) -> Result<String> {
-    let hash = xxhash3_128::Hasher::oneshot(contents);
-    let hash = format!("{:032x}", hash);
+    let hash = content_hash(contents);
 
     if let Some(store_path) = store_path {
         let dir = format!("{}/{}", store_path, hash_to_path(&hash)?);
@@ -73,12 +73,75 @@ pub fn hash_to_path(hash: &str) -> Result<String> {
     Ok(format!("{}/{}", first_two, rest).to_string())
 }
 
+/// Recovers the hash encoded in a store path like `<store_path>/c6/b8e869fa...`
+/// — the inverse of `hash_to_path`. Returns `None` if the path doesn't have
+/// at least the two components `hash_to_path` produces.
+fn path_to_hash(path: &str) -> Option<String> {
+    let components: Vec<&str> = path.split('/').collect();
+    if components.len() < 2 {
+        return None;
+    }
+    let prefix_part = components[components.len() - 2];
+    let rest_part = components[components.len() - 1];
+    let hash = format!("{}{}", prefix_part, rest_part);
+    if hash.is_empty() {
+        None
+    } else {
+        Some(hash)
+    }
+}
+
+/// A file found while walking a content-addressed store. Its hash isn't
+/// stored alongside it — the store's own naming convention means the path
+/// *is* the hash (see `path_to_hash`), so keeping a separate field would
+/// just be a second copy of the same value that could drift from the path.
+pub(crate) struct StoreFile {
+    pub path: String,
+}
+
+impl StoreFile {
+    /// The hash encoded in this file's path — not a freshly computed content
+    /// hash. Compare against `content_hash(&contents)` to check the two
+    /// still agree.
+    pub fn hash(&self) -> String {
+        path_to_hash(&self.path)
+            .expect("list_store_files only yields paths with a valid hash suffix")
+    }
+}
+
+/// Recursively walks every file under `store_path`. Used by both pin
+/// verification (does the file's content still match its path-encoded
+/// hash?) and garbage collection (which hashes currently exist in the
+/// store?).
+pub(crate) async fn list_store_files(fs: &Operator, store_path: &str) -> Result<Vec<StoreFile>> {
+    let prefix = format!("{}/", store_path.trim_end_matches('/'));
+    let mut lister = fs
+        .lister_with(&prefix)
+        .recursive(true)
+        .await
+        .context("failed to list pinned folder")?;
+
+    let mut files = Vec::new();
+    while let Some(entry) = lister.try_next().await? {
+        if entry.path().ends_with('/') {
+            continue;
+        }
+        if path_to_hash(entry.path()).is_some() {
+            files.push(StoreFile {
+                path: entry.path().to_string(),
+            });
+        }
+    }
+
+    Ok(files)
+}
+
 /// Recomputes the content hash of `contents` and errors if it doesn't match
 /// `expected`. Pinned storage is content-addressed by construction, so a
 /// mismatch means the file at `path` was modified (or corrupted) on disk
 /// after it was pinned — trust the hash over whatever bytes are found there.
 pub(crate) fn verify_hash(contents: &[u8], expected: &str, path: &str) -> Result<()> {
-    let actual = format!("{:032x}", xxhash3_128::Hasher::oneshot(contents));
+    let actual = content_hash(contents);
     if actual != expected {
         return Err(anyhow::anyhow!(
             "pinned file '{}' does not match its expected hash '{}' (got '{}') — \
@@ -201,12 +264,9 @@ mod tests {
         let root_content = read_hash_file(&dest_op, store_loc, &root).await?;
 
         // Verify that the hash of the root content matches the snapshot hash
-        let content_hash = format!(
-            "{:032x}",
-            xxhash3_128::Hasher::oneshot(root_content.as_bytes())
-        );
+        let computed_hash = content_hash(root_content.as_bytes());
         assert_eq!(
-            root, content_hash,
+            root, computed_hash,
             "Snapshot hash should match content hash"
         );
 

--- a/src/store/pinner/mod.rs
+++ b/src/store/pinner/mod.rs
@@ -123,7 +123,7 @@ pub(crate) async fn list_store_files(fs: &Operator, store_path: &str) -> Result<
 
     let mut files = Vec::new();
     while let Some(entry) = lister.try_next().await? {
-        if entry.path().ends_with('/') {
+        if entry.path().ends_with('/') || entry.name() == ".gitkeep" {
             continue;
         }
         if path_to_hash(entry.path()).is_some() {

--- a/src/store/pinner/spawn.rs
+++ b/src/store/pinner/spawn.rs
@@ -5,6 +5,11 @@ use async_trait::async_trait;
 use opendal::Operator;
 use std::collections::HashMap;
 
+use crate::config::FolderPather;
+use crate::hash::content_hash;
+use crate::pinfile;
+use crate::store::list_migration_fs_status;
+
 #[derive(Debug)]
 pub struct Spawn {
     files: Option<HashMap<String, PinnedFile>>,
@@ -128,4 +133,120 @@ impl Pinner for Spawn {
     async fn snapshot(&mut self, object_store: &Operator) -> Result<String> {
         super::snapshot(object_store, Some(self.pin_path.as_str()), &self.source_path).await
     }
+}
+
+// --- Store verification ---
+//
+// The checks below are specific to how the `Spawn` pinner stores data: a
+// content-addressed store of files at `<hash prefix>/<hash rest>` paths, with
+// each migration's lock.toml recording a root hash into that same store. A
+// different pinner (e.g. one backed by git history) wouldn't have a local
+// content-addressed store to walk at all, so "verify" for it would mean
+// something else entirely — this isn't a `Pinner`-trait-level concept yet.
+
+/// A pinned file whose contents no longer hash to the value encoded in its path.
+#[derive(Debug)]
+pub struct CorruptedFile {
+    pub path: String,
+    pub expected_hash: String,
+    pub actual_hash: String,
+}
+
+/// A migration whose lock.toml points at a root hash that isn't in the store.
+#[derive(Debug)]
+pub struct MissingRoot {
+    pub migration: String,
+    pub hash: String,
+}
+
+/// Result of verifying the Spawn pinned store.
+#[derive(Debug, Default)]
+pub struct VerifyResult {
+    /// Number of pinned files whose content hash was checked.
+    pub checked_count: usize,
+    /// Pinned files whose contents don't match their path-encoded hash.
+    pub corrupted: Vec<CorruptedFile>,
+    /// Migrations whose lock.toml root hash has no corresponding file in the store.
+    pub missing_roots: Vec<MissingRoot>,
+}
+
+/// Walks every file in the pinned folder and recomputes its content hash,
+/// comparing it against the hash encoded in its path. Unlike `verify_hash`,
+/// this collects every mismatch instead of stopping at the first one.
+async fn verify_store_contents(
+    fs: &Operator,
+    pinned_folder: &str,
+) -> Result<(usize, Vec<CorruptedFile>)> {
+    let files = super::list_store_files(fs, pinned_folder).await?;
+
+    let mut checked_count = 0;
+    let mut corrupted = Vec::new();
+
+    for file in files {
+        let contents = fs
+            .read(&file.path)
+            .await
+            .with_context(|| format!("failed to read pinned file at {}", file.path))?
+            .to_bytes();
+        let actual_hash = content_hash(&contents);
+        let expected_hash = file.hash();
+
+        checked_count += 1;
+        if actual_hash != expected_hash {
+            corrupted.push(CorruptedFile {
+                path: file.path,
+                expected_hash,
+                actual_hash,
+            });
+        }
+    }
+
+    Ok((checked_count, corrupted))
+}
+
+/// Checks that every migration's lock.toml root hash has a corresponding file
+/// present in the pinned store.
+async fn verify_lock_roots(fs: &Operator, pather: &FolderPather) -> Result<Vec<MissingRoot>> {
+    let mut missing = Vec::new();
+
+    let statuses = list_migration_fs_status(fs, pather, None).await?;
+
+    for (name, status) in statuses {
+        if !status.has_lock_toml {
+            continue;
+        }
+
+        let lock_path = pather.migration_lock_file_path(&name);
+        let lock_data = pinfile::load_lock_file(fs, &lock_path)
+            .await
+            .with_context(|| format!("failed to load lock file for migration {}", name))?;
+
+        let root_path = format!(
+            "{}/{}",
+            pather.pinned_folder(),
+            super::hash_to_path(&lock_data.pin)?
+        );
+        if !fs.exists(&root_path).await? {
+            missing.push(MissingRoot {
+                migration: name,
+                hash: lock_data.pin,
+            });
+        }
+    }
+
+    Ok(missing)
+}
+
+/// Verifies the Spawn pinned store: every file's contents must match its
+/// path-encoded hash, and every migration's lock.toml root hash must exist
+/// in the store.
+pub async fn verify_store(fs: &Operator, pather: &FolderPather) -> Result<VerifyResult> {
+    let (checked_count, corrupted) = verify_store_contents(fs, &pather.pinned_folder()).await?;
+    let missing_roots = verify_lock_roots(fs, pather).await?;
+
+    Ok(VerifyResult {
+        checked_count,
+        corrupted,
+        missing_roots,
+    })
 }

--- a/src/store/pinner/spawn.rs
+++ b/src/store/pinner/spawn.rs
@@ -226,7 +226,8 @@ async fn verify_lock_roots(fs: &Operator, pather: &FolderPather) -> Result<Vec<M
             pather.pinned_folder(),
             super::hash_to_path(&lock_data.pin)?
         );
-        if !fs.exists(&root_path).await? {
+        let root_is_file = fs.exists(&root_path).await? && fs.stat(&root_path).await?.is_file();
+        if !root_is_file {
             missing.push(MissingRoot {
                 migration: name,
                 hash: lock_data.pin,

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use crate::engine::EngineType;
 use crate::escape::{EscapedIdentifier, EscapedLiteral};
+use crate::hash::content_hash;
 use crate::secrets::{SecretsRenderMode, SecretsRepository};
 use crate::store::pinner::latest::Latest;
 use crate::store::pinner::spawn::Spawn;
@@ -16,7 +17,6 @@ use uuid::Uuid;
 use anyhow::{Context, Result};
 use minijinja::context;
 use std::sync::Arc;
-use twox_hash::xxhash3_128;
 
 /// Maps an EngineType to the appropriate SQL dialect for formatting.
 ///
@@ -340,8 +340,7 @@ impl StreamingGeneration {
     /// checksum. As a side effect, this also means secret rotation never
     /// changes a migration's recorded checksum.
     pub fn raw_checksum(&self) -> String {
-        let hash = xxhash3_128::Hasher::oneshot(self.template_contents.as_bytes());
-        format!("{:032x}", hash)
+        content_hash(self.template_contents.as_bytes())
     }
 
     /// The pin actually used to build this render's component store — see
@@ -950,10 +949,7 @@ mod tests {
         let source = r#"SELECT {{ secret("application_password") }};"#;
         let gen = streaming_generation(source, literal_secret_repo("hunter2"));
 
-        let expected = format!(
-            "{:032x}",
-            twox_hash::xxhash3_128::Hasher::oneshot(source.as_bytes())
-        );
+        let expected = content_hash(source.as_bytes());
         assert_eq!(gen.raw_checksum(), expected);
     }
 

--- a/tests/migration_build.rs
+++ b/tests/migration_build.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use spawn_db::{
     commands::{
         BuildMigration, Check, Command, NewMigration, NewTest, Outcome, PinCleanup, PinError,
-        PinMigration,
+        PinMigration, PinVerify,
     },
     config::{Config, ConfigLoaderSaver},
     engine::{CommandSpec, EngineType, TargetConfig},
@@ -843,6 +843,107 @@ async fn test_pin_cleanup_finds_and_deletes_orphans() -> Result<(), Box<dyn std:
         files_after_cleanup.len(),
         "cleanup should delete 4 orphaned pinned files"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pin_verify_passes_on_untampered_store() -> Result<(), Box<dyn std::error::Error>> {
+    let helper = MigrationTestHelper::new_empty().await?;
+
+    let migration_name = helper.create_migration("test-migration").await?;
+    helper.pin_migration(&migration_name).await?;
+
+    let config = helper.load_config().await?;
+    let outcome = PinVerify.execute(&config).await?;
+
+    let Outcome::PinVerify {
+        corrupted_count,
+        missing_root_count,
+    } = outcome
+    else {
+        panic!("Expected Outcome::PinVerify");
+    };
+
+    assert_eq!(corrupted_count, 0);
+    assert_eq!(missing_root_count, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pin_verify_detects_corrupted_file() -> Result<(), Box<dyn std::error::Error>> {
+    let helper =
+        MigrationTestHelper::new_from_local_folder("./static/tests/build_with_component").await?;
+
+    let migration_name = "20240907212659-initial";
+    helper.pin_migration(migration_name).await?;
+
+    // Tamper with a pinned blob directly on disk, the same way a stray edit
+    // to a file under pinned/ would: its path stays content-addressed by the
+    // *original* content's hash, so the path and the bytes at that path now
+    // disagree.
+    let original_component = helper
+        .fs
+        .read("/db/components/util/add_func.sql")
+        .await?
+        .to_bytes();
+    let hash = store::pinner::pin_contents(&helper.fs, None, &original_component).await?;
+    let pinned_path = format!("/db/pinned/{}", store::pinner::hash_to_path(&hash)?);
+    helper
+        .fs
+        .write(&pinned_path, "-- tampered contents".to_string())
+        .await?;
+
+    let config = helper.load_config().await?;
+    let outcome = PinVerify.execute(&config).await?;
+
+    let Outcome::PinVerify {
+        corrupted_count,
+        missing_root_count,
+    } = outcome
+    else {
+        panic!("Expected Outcome::PinVerify");
+    };
+
+    assert_eq!(corrupted_count, 1, "should detect the one tampered file");
+    assert_eq!(missing_root_count, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pin_verify_detects_missing_root() -> Result<(), Box<dyn std::error::Error>> {
+    let helper = MigrationTestHelper::new_empty().await?;
+
+    let migration_name = helper.create_migration("test-migration").await?;
+    helper.pin_migration(&migration_name).await?;
+
+    // Point the migration's lock.toml at a root hash that doesn't exist in
+    // the store, simulating a pinned file (or its whole subtree) having been
+    // deleted out from under a migration that still references it.
+    let lock_path = format!("/db/migrations/{}/lock.toml", migration_name);
+    helper
+        .fs
+        .write(
+            &lock_path,
+            "pin = \"00000000000000000000000000000000\"".to_string(),
+        )
+        .await?;
+
+    let config = helper.load_config().await?;
+    let outcome = PinVerify.execute(&config).await?;
+
+    let Outcome::PinVerify {
+        corrupted_count,
+        missing_root_count,
+    } = outcome
+    else {
+        panic!("Expected Outcome::PinVerify");
+    };
+
+    assert_eq!(corrupted_count, 0);
+    assert_eq!(missing_root_count, 1, "should detect the missing root hash");
 
     Ok(())
 }


### PR DESCRIPTION
Implements a new pin verify so that we can verify in CI that pinned file hashes match their file name, and that pinned migrations all refer to a real file in the pinned folder.